### PR TITLE
[Bugfix] Fix presence state not rendering immediately

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -181,7 +181,7 @@ export default function usePresence(
     hasMounted.current = true;
   }, []);
 
-  const state = useQuery(presence.list, { roomToken: roomTokenRef.current ?? "" });
+  const state = useQuery(presence.list, roomToken ? { roomToken } : "skip");
   return useMemo(
     () =>
       state?.slice().sort((a, b) => {


### PR DESCRIPTION
Previously, the `usePresence` hook would pass in an empty string if the `roomToken` hadn't been initialized yet. This was incorrect and would cause the presence UI to show up as empty until we re-ran the query after another heartbeat was executed. Instead, we should not run the query if it isn't available yet.

We now skip the query if the `roomToken` is not available. This causes the `usePresence` to return the correct results once they are available and not cause a delay in rendering the UI.