### PR TITLE
Remove the client code check

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -5,10 +5,6 @@ import { useQuery, useMutation, useConvex } from "convex/react";
 import { FunctionReference } from "convex/server";
 import useSingleFlight from "./useSingleFlight.js";
 
-if (typeof window === "undefined") {
-  throw new Error("this is frontend code, but it's running somewhere else!");
-}
-
 // Interface in your Convex app /convex directory that implements these
 // functions by calling into the presence component, e.g., like this:
 //


### PR DESCRIPTION
This check [breaks Presence](https://discord.com/channels/1019350475847499849/1316482576042557531/1380585790123413604) when used with React Router v7. `"use client"` is a Next-specific directive, so other frameworks might try to call this code during SSR. I don’t believe there are any real benefits from making sure this code doesn’t run outside of the client except develpoer convenience when there are evident import issues.