### PR TITLE
list room/user helpers

### DIFF
--- a/example-with-auth/convex/_generated/api.d.ts
+++ b/example-with-auth/convex/_generated/api.d.ts
@@ -71,26 +71,14 @@ export declare const components: {
       listRoom: FunctionReference<
         "query",
         "internal",
-        { limit?: number; roomId: string },
+        { limit?: number; onlineOnly?: boolean; roomId: string },
         Array<{ lastDisconnected: number; online: boolean; userId: string }>
-      >;
-      listRoomOnline: FunctionReference<
-        "query",
-        "internal",
-        { limit?: number; roomId: string },
-        Array<string>
       >;
       listUser: FunctionReference<
         "query",
         "internal",
-        { limit?: number; userId: string },
+        { limit?: number; onlineOnly?: boolean; userId: string },
         Array<{ lastDisconnected: number; online: boolean; roomId: string }>
-      >;
-      listUserOnline: FunctionReference<
-        "query",
-        "internal",
-        { limit?: number; userId: string },
-        Array<string>
       >;
       removeRoom: FunctionReference<
         "mutation",

--- a/example-with-auth/convex/_generated/api.d.ts
+++ b/example-with-auth/convex/_generated/api.d.ts
@@ -68,6 +68,30 @@ export declare const components: {
         { limit?: number; roomToken: string },
         Array<{ lastDisconnected: number; online: boolean; userId: string }>
       >;
+      listRoom: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; roomId: string },
+        Array<{ lastDisconnected: number; online: boolean; userId: string }>
+      >;
+      listRoomOnline: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; roomId: string },
+        Array<string>
+      >;
+      listUser: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; userId: string },
+        Array<{ lastDisconnected: number; online: boolean; roomId: string }>
+      >;
+      listUserOnline: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; userId: string },
+        Array<string>
+      >;
       removeRoom: FunctionReference<
         "mutation",
         "internal",

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -67,26 +67,14 @@ export declare const components: {
       listRoom: FunctionReference<
         "query",
         "internal",
-        { limit?: number; roomId: string },
+        { limit?: number; onlineOnly?: boolean; roomId: string },
         Array<{ lastDisconnected: number; online: boolean; userId: string }>
-      >;
-      listRoomOnline: FunctionReference<
-        "query",
-        "internal",
-        { limit?: number; roomId: string },
-        Array<string>
       >;
       listUser: FunctionReference<
         "query",
         "internal",
-        { limit?: number; userId: string },
+        { limit?: number; onlineOnly?: boolean; userId: string },
         Array<{ lastDisconnected: number; online: boolean; roomId: string }>
-      >;
-      listUserOnline: FunctionReference<
-        "query",
-        "internal",
-        { limit?: number; userId: string },
-        Array<string>
       >;
       removeRoom: FunctionReference<
         "mutation",

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -64,6 +64,30 @@ export declare const components: {
         { limit?: number; roomToken: string },
         Array<{ lastDisconnected: number; online: boolean; userId: string }>
       >;
+      listRoom: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; roomId: string },
+        Array<{ lastDisconnected: number; online: boolean; userId: string }>
+      >;
+      listRoomOnline: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; roomId: string },
+        Array<string>
+      >;
+      listUser: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; userId: string },
+        Array<{ lastDisconnected: number; online: boolean; roomId: string }>
+      >;
+      listUserOnline: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; userId: string },
+        Array<string>
+      >;
       removeRoom: FunctionReference<
         "mutation",
         "internal",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -80,23 +80,11 @@ export class Presence<RoomId extends string = string, UserId extends string = st
   async listRoom(
     ctx: RunQueryCtx,
     roomId: RoomId,
+    onlineOnly: boolean = false, // only show users online in the room
     limit: number = 104
   ): Promise<Array<{ userId: UserId; online: boolean; lastDisconnected: number }>> {
-    return ctx.runQuery(this.component.public.listRoom, { roomId, limit }) as Promise<
+    return ctx.runQuery(this.component.public.listRoom, { roomId, onlineOnly, limit }) as Promise<
       { userId: UserId; online: boolean; lastDisconnected: number }[]
-    >;
-  }
-
-  /**
-   * List all online users in a room.
-   */
-  async listRoomOnline(
-    ctx: RunQueryCtx,
-    roomId: RoomId,
-    limit: number = 104
-  ): Promise<Array<UserId>> {
-    return ctx.runQuery(this.component.public.listRoomOnline, { roomId, limit }) as Promise<
-      UserId[]
     >;
   }
 
@@ -106,23 +94,11 @@ export class Presence<RoomId extends string = string, UserId extends string = st
   async listUser(
     ctx: RunQueryCtx,
     userId: UserId,
+    onlineOnly: boolean = false, // only show rooms the user is online in
     limit: number = 104
   ): Promise<Array<{ roomId: RoomId; online: boolean; lastDisconnected: number }>> {
-    return ctx.runQuery(this.component.public.listUser, { userId, limit }) as Promise<
+    return ctx.runQuery(this.component.public.listUser, { userId, onlineOnly, limit }) as Promise<
       { roomId: RoomId; online: boolean; lastDisconnected: number }[]
-    >;
-  }
-
-  /**
-   * List all rooms a user is online in.
-   */
-  async listUserOnline(
-    ctx: RunQueryCtx,
-    userId: UserId,
-    limit: number = 104
-  ): Promise<Array<RoomId>> {
-    return ctx.runQuery(this.component.public.listUserOnline, { userId, limit }) as Promise<
-      RoomId[]
     >;
   }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,25 +1,43 @@
 import { api } from "../component/_generated/api.js";
 import { RunMutationCtx, RunQueryCtx, UseApi } from "./utils.js";
 
-// Wrapper around Presence component for use in Convex server functions.
-//
-// See ../react/index.ts for the usePresence hook that maintains presence in a
-// client-side React component and ../component/public.ts for the implementation
-// of these functions.
-export class Presence {
+export class Presence<RoomId extends string = string, UserId extends string = string> {
+  /**
+   * The Presence component tracks the presence of users in a room.
+   * A "room" is a unit of presence state, e.g., a chat room, document, game
+   * etc. Rooms need a unique string ID that in many applications will just be a
+   * Convex ID.
+   *
+   * See [../react/index.ts](../react/index.ts) for the usePresence hook that
+   * maintains presence in a client-side React component and
+   * [public.ts](../component/public.ts) for the implementation of these
+   * functions.
+   */
   constructor(private component: UseApi<typeof api>) {}
 
-  // Keepalive heartbeat mutation. Session ID must be unique for a given room/user.
-  // Interval is the time between heartbeats. User will be disconnected if no
-  // heartbeat is received for 2.5x the interval or if a graceful disconnect
-  // message is received. Returns room and session tokens.
+  /**
+   * ============================================================================
+   * MAIN PRESENCE FUNCTIONS
+   * ============================================================================
+   *
+   * These functions are the core API for maintaining presence state.
+   * They will typically be exposed directly to end users, with heartbeat
+   * wrapped in authentication.
+   */
+
+  /**
+   * Keepalive heartbeat mutation. Session ID must be unique for a given
+   * room/user. Interval is the time between heartbeats. User will be
+   * disconnected if no heartbeat is received for 2.5x the interval or if a
+   * graceful disconnect message is received. Returns room and session tokens.
+   */
   async heartbeat(
     ctx: RunMutationCtx,
-    roomId: string,
-    userId: string,
+    roomId: RoomId,
+    userId: UserId,
     sessionId: string,
     interval: number
-  ) {
+  ): Promise<{ roomToken: string; sessionToken: string }> {
     return ctx.runMutation(this.component.public.heartbeat, {
       roomId,
       userId,
@@ -28,24 +46,97 @@ export class Presence {
     });
   }
 
-  // List presence state for all users in the room, up to the limit of users.
-  async list(ctx: RunQueryCtx, roomToken: string, limit: number = 104) {
-    return ctx.runQuery(this.component.public.list, { roomToken, limit });
+  /**
+   * List presence state for all users in the room, up to the limit of users.
+   */
+  async list(
+    ctx: RunQueryCtx,
+    roomToken: string,
+    limit: number = 104
+  ): Promise<Array<{ userId: UserId; online: boolean; lastDisconnected: number }>> {
+    return ctx.runQuery(this.component.public.list, { roomToken, limit }) as Promise<
+      { userId: UserId; online: boolean; lastDisconnected: number }[]
+    >;
   }
 
   // Gracefully disconnect a user.
-  async disconnect(ctx: RunMutationCtx, sessionToken: string) {
+  async disconnect(ctx: RunMutationCtx, sessionToken: string): Promise<null> {
     return ctx.runMutation(this.component.public.disconnect, { sessionToken });
   }
 
-  // Remove a user from a room. If you need to track which rooms a user is in
-  // you can store this in your calling application.
-  async removeRoomUser(ctx: RunMutationCtx, roomId: string, userId: string) {
+  /**
+   * ============================================================================
+   * HELPERS AND MAINTENANCE FUNCTIONS
+   * ============================================================================
+   *
+   * These functions are convenient to use within your parent application but
+   * don't include their own authentication so you should be careful about exposing
+   * them directly to end users.
+   */
+
+  /**
+   * List all users in a room.
+   */
+  async listRoom(
+    ctx: RunQueryCtx,
+    roomId: RoomId,
+    limit: number = 104
+  ): Promise<Array<{ userId: UserId; online: boolean; lastDisconnected: number }>> {
+    return ctx.runQuery(this.component.public.listRoom, { roomId, limit }) as Promise<
+      { userId: UserId; online: boolean; lastDisconnected: number }[]
+    >;
+  }
+
+  /**
+   * List all online users in a room.
+   */
+  async listRoomOnline(
+    ctx: RunQueryCtx,
+    roomId: RoomId,
+    limit: number = 104
+  ): Promise<Array<UserId>> {
+    return ctx.runQuery(this.component.public.listRoomOnline, { roomId, limit }) as Promise<
+      UserId[]
+    >;
+  }
+
+  /**
+   * List all rooms a user is in.
+   */
+  async listUser(
+    ctx: RunQueryCtx,
+    userId: UserId,
+    limit: number = 104
+  ): Promise<Array<{ roomId: RoomId; online: boolean; lastDisconnected: number }>> {
+    return ctx.runQuery(this.component.public.listUser, { userId, limit }) as Promise<
+      { roomId: RoomId; online: boolean; lastDisconnected: number }[]
+    >;
+  }
+
+  /**
+   * List all rooms a user is online in.
+   */
+  async listUserOnline(
+    ctx: RunQueryCtx,
+    userId: UserId,
+    limit: number = 104
+  ): Promise<Array<RoomId>> {
+    return ctx.runQuery(this.component.public.listUserOnline, { userId, limit }) as Promise<
+      RoomId[]
+    >;
+  }
+
+  /**
+   * Remove a user from a room.
+   */
+  async removeRoomUser(ctx: RunMutationCtx, roomId: RoomId, userId: UserId): Promise<null> {
     return ctx.runMutation(this.component.public.removeRoomUser, { roomId, userId });
   }
 
-  // Remove a room.
-  async removeRoom(ctx: RunMutationCtx, roomId: string) {
+  /**
+   * Remove a room.
+   */
+  async removeRoom(ctx: RunMutationCtx, roomId: RoomId): Promise<null> {
     return ctx.runMutation(this.component.public.removeRoom, { roomId });
   }
 }

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -47,6 +47,30 @@ export type Mounts = {
       { limit?: number; roomToken: string },
       Array<{ lastDisconnected: number; online: boolean; userId: string }>
     >;
+    listRoom: FunctionReference<
+      "query",
+      "public",
+      { limit?: number; roomId: string },
+      Array<{ lastDisconnected: number; online: boolean; userId: string }>
+    >;
+    listRoomOnline: FunctionReference<
+      "query",
+      "public",
+      { limit?: number; roomId: string },
+      Array<string>
+    >;
+    listUser: FunctionReference<
+      "query",
+      "public",
+      { limit?: number; userId: string },
+      Array<{ lastDisconnected: number; online: boolean; roomId: string }>
+    >;
+    listUserOnline: FunctionReference<
+      "query",
+      "public",
+      { limit?: number; userId: string },
+      Array<string>
+    >;
     removeRoom: FunctionReference<
       "mutation",
       "public",

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -50,26 +50,14 @@ export type Mounts = {
     listRoom: FunctionReference<
       "query",
       "public",
-      { limit?: number; roomId: string },
+      { limit?: number; onlineOnly?: boolean; roomId: string },
       Array<{ lastDisconnected: number; online: boolean; userId: string }>
-    >;
-    listRoomOnline: FunctionReference<
-      "query",
-      "public",
-      { limit?: number; roomId: string },
-      Array<string>
     >;
     listUser: FunctionReference<
       "query",
       "public",
-      { limit?: number; userId: string },
+      { limit?: number; onlineOnly?: boolean; userId: string },
       Array<{ lastDisconnected: number; online: boolean; roomId: string }>
-    >;
-    listUserOnline: FunctionReference<
-      "query",
-      "public",
-      { limit?: number; userId: string },
-      Array<string>
     >;
     removeRoom: FunctionReference<
       "mutation",

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -85,23 +85,6 @@ export const heartbeat = mutation({
   },
 });
 
-async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
-  return (
-    (await ctx.db
-      .query("presence")
-      .withIndex("user_online_room", (q) =>
-        q.eq("userId", userId).eq("online", true).eq("roomId", roomId)
-      )
-      .unique()) ||
-    (await ctx.db
-      .query("presence")
-      .withIndex("user_online_room", (q) =>
-        q.eq("userId", userId).eq("online", false).eq("roomId", roomId)
-      )
-      .unique())
-  );
-}
-
 export const list = query({
   args: {
     roomToken: v.string(),
@@ -384,5 +367,22 @@ export const removeRoom = mutation({
     }
   },
 });
+
+async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
+  return (
+    (await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) =>
+        q.eq("userId", userId).eq("online", true).eq("roomId", roomId)
+      )
+      .unique()) ||
+    (await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) =>
+        q.eq("userId", userId).eq("online", false).eq("roomId", roomId)
+      )
+      .unique())
+  );
+}
 
 // TODO: rotate the room tokens

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -5,7 +5,7 @@
 // can be used in Convex server functions.
 
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { mutation, query, QueryCtx } from "./_generated/server.js";
 import { api } from "./_generated/api.js";
 
 export const heartbeat = mutation({
@@ -32,10 +32,7 @@ export const heartbeat = mutation({
     }
 
     // Set user online if needed.
-    const userPresence = await ctx.db
-      .query("presence")
-      .withIndex("room_user", (q) => q.eq("roomId", roomId).eq("userId", userId))
-      .unique();
+    const userPresence = await getUserPresence(ctx, userId, roomId);
     if (!userPresence) {
       await ctx.db.insert("presence", { roomId, userId, online: true, lastDisconnected: 0 });
     } else if (!userPresence.online) {
@@ -88,6 +85,23 @@ export const heartbeat = mutation({
   },
 });
 
+async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
+  return (
+    (await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) =>
+        q.eq("userId", userId).eq("online", true).eq("roomId", roomId)
+      )
+      .unique()) ||
+    (await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) =>
+        q.eq("userId", userId).eq("online", false).eq("roomId", roomId)
+      )
+      .unique())
+  );
+}
+
 export const list = query({
   args: {
     roomToken: v.string(),
@@ -132,6 +146,98 @@ export const list = query({
   },
 });
 
+export const listRoom = query({
+  args: {
+    roomId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      userId: v.string(),
+      online: v.boolean(),
+      lastDisconnected: v.number(),
+    })
+  ),
+  handler: async (ctx, { roomId, limit = 104 }) => {
+    const online = await ctx.db
+      .query("presence")
+      .withIndex("room_order", (q) => q.eq("roomId", roomId).eq("online", true))
+      .take(limit);
+    const offline = await ctx.db
+      .query("presence")
+      .withIndex("room_order", (q) => q.eq("roomId", roomId).eq("online", false))
+      .order("desc")
+      .take(limit - online.length);
+    const results = [...online, ...offline];
+    return results.map(({ userId, online, lastDisconnected }) => ({
+      userId,
+      online,
+      lastDisconnected,
+    }));
+  },
+});
+
+export const listRoomOnline = query({
+  args: {
+    roomId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(v.string()),
+  handler: async (ctx, { roomId, limit = 104 }) => {
+    const online = await ctx.db
+      .query("presence")
+      .withIndex("room_order", (q) => q.eq("roomId", roomId).eq("online", true))
+      .take(limit);
+    return online.map(({ userId }) => userId);
+  },
+});
+
+export const listUser = query({
+  args: {
+    userId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      roomId: v.string(),
+      online: v.boolean(),
+      lastDisconnected: v.number(),
+    })
+  ),
+  handler: async (ctx, { userId, limit = 104 }) => {
+    const online = await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) => q.eq("userId", userId).eq("online", true))
+      .take(limit);
+    const offline = await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) => q.eq("userId", userId).eq("online", false))
+      .order("desc")
+      .take(limit - online.length);
+    const results = [...online, ...offline];
+    return results.map(({ roomId, online, lastDisconnected }) => ({
+      roomId,
+      online,
+      lastDisconnected,
+    }));
+  },
+});
+
+export const listUserOnline = query({
+  args: {
+    userId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(v.string()),
+  handler: async (ctx, { userId, limit = 104 }) => {
+    const online = await ctx.db
+      .query("presence")
+      .withIndex("user_online_room", (q) => q.eq("userId", userId).eq("online", true))
+      .take(limit);
+    return online.map(({ roomId }) => roomId);
+  },
+});
+
 export const disconnect = mutation({
   args: {
     sessionToken: v.string(),
@@ -161,10 +267,7 @@ export const disconnect = mutation({
     const { roomId, userId } = session;
     await ctx.db.delete(session._id);
 
-    const userPresence = await ctx.db
-      .query("presence")
-      .withIndex("room_user", (q) => q.eq("roomId", roomId).eq("userId", userId))
-      .unique();
+    const userPresence = await getUserPresence(ctx, userId, roomId);
     if (!userPresence) {
       console.error("Should not have a session token", sessionToken, "without a user presence");
       return;
@@ -198,15 +301,12 @@ export const removeRoomUser = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { roomId, userId }) => {
-    const state = await ctx.db
-      .query("presence")
-      .withIndex("room_user", (q) => q.eq("roomId", roomId).eq("userId", userId))
-      .unique();
-    if (!state) {
+    const userPresence = await getUserPresence(ctx, userId, roomId);
+    if (!userPresence) {
       console.warn("User not in room", roomId, userId);
       return null;
     }
-    await ctx.db.delete(state._id);
+    await ctx.db.delete(userPresence._id);
 
     // Remove the user from all sessions.
     const sessions = await ctx.db
@@ -244,7 +344,7 @@ export const removeRoom = mutation({
   handler: async (ctx, { roomId }) => {
     const presenceRecords = await ctx.db
       .query("presence")
-      .withIndex("room_user", (q) => q.eq("roomId", roomId))
+      .withIndex("room_order", (q) => q.eq("roomId", roomId))
       .collect();
     for (const presence of presenceRecords) {
       await ctx.db.delete(presence._id);

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -9,7 +9,7 @@ export default defineSchema({
     online: v.boolean(), // Whether any user session is online.
     lastDisconnected: v.number(), // Timestamp of last disconnect.
   })
-    .index("room_user", ["roomId", "userId"])
+    .index("user_online_room", ["userId", "online", "roomId"])
     .index("room_order", ["roomId", "online", "lastDisconnected"]),
 
   // Individual sessions for each browser tab/connection.


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add functions to list all/online users in a room without a token plus list all/online rooms for a user.

Shout out @ianmacartney who already wrote https://github.com/get-convex/presence/pull/8 while I was doing this and not checking Slack. I stole some of those changes. Thanks Ian!

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
