### PR TITLE
add optional data to each presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 .eslintcache
 # components are libraries!
 package-lock.json
+pnpm-lock.yaml
+pnpm-workspace.yaml
 
 # this is a package-json-redirect stub dir, see https://github.com/andrewbranch/example-subpath-exports-ts-compat?tab=readme-ov-file
 react/package.json

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -62,7 +62,12 @@ export declare const components: {
         "query",
         "internal",
         { limit?: number; roomToken: string },
-        Array<{ lastDisconnected: number; online: boolean; userId: string }>
+        Array<{
+          data?: any;
+          lastDisconnected: number;
+          online: boolean;
+          userId: string;
+        }>
       >;
       listRoom: FunctionReference<
         "query",
@@ -86,6 +91,12 @@ export declare const components: {
         "mutation",
         "internal",
         { roomId: string; userId: string },
+        null
+      >;
+      updateRoomUser: FunctionReference<
+        "mutation",
+        "internal",
+        { data?: any; roomId: string; userId: string },
         null
       >;
     };

--- a/example/convex/presence.ts
+++ b/example/convex/presence.ts
@@ -31,3 +31,12 @@ export const disconnect = mutation({
     return await presence.disconnect(ctx, sessionToken);
   },
 });
+
+export const updateRoomUser = mutation({
+  args: { roomId: v.string(), userId: v.string(), data: v.any() },
+  handler: async (ctx, { roomId, userId, data }) => {
+    // TODO: Add your auth checks here.
+    console.log("updateRoomUser", roomId, userId, data);
+    return await presence.updateRoomUser(ctx, roomId, userId, data);
+  }
+})

--- a/example/convex/presence.ts
+++ b/example/convex/presence.ts
@@ -36,7 +36,6 @@ export const updateRoomUser = mutation({
   args: { roomId: v.string(), userId: v.string(), data: v.any() },
   handler: async (ctx, { roomId, userId, data }) => {
     // TODO: Add your auth checks here.
-    console.log("updateRoomUser", roomId, userId, data);
     return await presence.updateRoomUser(ctx, roomId, userId, data);
   }
 })

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,17 +1,29 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { api } from "../convex/_generated/api";
 import usePresence from "@convex-dev/presence/react";
 import FacePile from "@convex-dev/presence/facepile";
+import { useMutation } from "convex/react";
 
 export default function App(): React.ReactElement {
   const [name] = useState(() => "User " + Math.floor(Math.random() * 10000));
   const presenceState = usePresence(api.presence, "my-chat-room", name);
+  const updateRoomUser = useMutation(api.presence.updateRoomUser);
+  const updateIsTyping = useCallback((isTyping: boolean) => {
+    updateRoomUser({
+      roomId: "my-chat-room",
+      userId: name,
+      data: { isTyping },
+    });
+  }, [name, updateRoomUser]);
 
   return (
     <main>
       <h1>Convex Presence Example</h1>
       <p>my-chat-room, {name}</p>
       <FacePile presenceState={presenceState ?? []} />
+      <div style={{ padding: "20px" }}>
+        <input onFocus={() => updateIsTyping(true)} onBlur={() => updateIsTyping(false)} />
+      </div>
     </main>
   );
 }

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -4,3 +4,8 @@ main {
   margin: 0 auto;
   text-align: center;
 }
+
+/* Custom style when online and typing */
+.avatar.online[data-presence-isTyping="true"] {
+  border: 2px solid #00f;
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -53,10 +53,22 @@ export class Presence<RoomId extends string = string, UserId extends string = st
     ctx: RunQueryCtx,
     roomToken: string,
     limit: number = 104
-  ): Promise<Array<{ userId: UserId; online: boolean; lastDisconnected: number }>> {
+  ): Promise<Array<{ userId: UserId; online: boolean; lastDisconnected: number, data?: unknown }>> {
     return ctx.runQuery(this.component.public.list, { roomToken, limit }) as Promise<
-      { userId: UserId; online: boolean; lastDisconnected: number }[]
+      { userId: UserId; online: boolean; lastDisconnected: number, data?: unknown }[]
     >;
+  }
+
+  /**
+   * Updates a users presence data in a room.
+   */
+  async updateRoomUser(
+    ctx: RunMutationCtx,
+    roomId: RoomId,
+    userId: UserId,
+    data?: unknown
+  ): Promise<null> {
+    return ctx.runMutation(this.component.public.updateRoomUser, { roomId, userId, data });
   }
 
   // Gracefully disconnect a user.

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -45,7 +45,12 @@ export type Mounts = {
       "query",
       "public",
       { limit?: number; roomToken: string },
-      Array<{ lastDisconnected: number; online: boolean; userId: string }>
+      Array<{
+        data?: any;
+        lastDisconnected: number;
+        online: boolean;
+        userId: string;
+      }>
     >;
     listRoom: FunctionReference<
       "query",
@@ -69,6 +74,12 @@ export type Mounts = {
       "mutation",
       "public",
       { roomId: string; userId: string },
+      null
+    >;
+    updateRoomUser: FunctionReference<
+      "mutation",
+      "public",
+      { data?: any; roomId: string; userId: string },
       null
     >;
   };

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -8,6 +8,7 @@ export default defineSchema({
     userId: v.string(), // Unique identifier for a user in the room.
     online: v.boolean(), // Whether any user session is online.
     lastDisconnected: v.number(), // Timestamp of last disconnect.
+    data: v.optional(v.any()), // Optional data for presence in the room.
   })
     .index("user_online_room", ["userId", "online", "roomId"])
     .index("room_order", ["roomId", "online", "lastDisconnected"]),

--- a/src/facepile/facepile.css
+++ b/src/facepile/facepile.css
@@ -49,7 +49,6 @@
   border-radius: 50%;
   object-fit: cover;
   display: block;
-  vertical-align: top;
 }
 
 .more {
@@ -88,6 +87,14 @@
 .tooltip-status {
   font-size: 0.625rem;
   color: #6b7280;
+}
+
+.tooltip-data {
+  font-size: 0.625rem;
+  color: #9ca3af;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .more-container {
@@ -143,7 +150,6 @@
   border-radius: 50%;
   object-fit: cover;
   display: block;
-  vertical-align: top;
 }
 
 .dropdown-info {

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -49,6 +49,7 @@ export interface PresenceState {
   userId: string;
   online: boolean;
   lastDisconnected: number;
+  data?: unknown;
   // Set these accordingly in your Convex app.
   // See ../../example-with-auth/convex/presence.ts for an example.
   name?: string;


### PR DESCRIPTION
Changes to the component:
- added optional "data" field to the presence so it has similar features as the one at convex-helpers;
- added a seperate mutation to not break the API of the component; 

Some changes to the basic example:
- updated the basic example to select a random emoji based on user name, and spread the custom presence data into the facepile element to allow custom styling;

Screenshot below shows User 6314 typing, User 2803 sees the presence state:
<img width="1155" height="294" alt="presence" src="https://github.com/user-attachments/assets/cb3938b6-7356-4207-9ad8-cc9973dd1d37" />
