### PR TITLE
React Native support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ This uses the basic `FacePile` component included with this package but you can
 easily copy this code and use the `usePresence` hook directly to implement your
 own styling.
 
+### React Native support
+
+If you're using React Native, install these optional dependencies:
+```sh
+npx expo install react-native expo-crypto
+```
+
+and then import the `usePresence` hook from `@convex-dev/presence/react-native`:
+```ts
+import { usePresence } from '@convex-dev/presence/react-native'; 
+```
+
+*Note: The <FacePile /> component currently doesn't have a React Native equivalent, but you can easily create your own.*
+
 ## Additional functionality
 
 The component interface for the `Presence` class is defined in

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "keywords": [
     "convex",
     "component",
-    "presence"
+    "presence",
+    "react",
+    "react-native",
+    "expo"
   ],
   "type": "module",
   "scripts": {
@@ -55,6 +58,18 @@
         "default": "./dist/commonjs/react/index.js"
       }
     },
+    "./react-native": {
+      "import": {
+        "@convex-dev/component-source": "./src/react-native/index.ts",
+        "types": "./dist/esm/react-native/index.d.ts",
+        "default": "./dist/esm/react-native/index.js"
+      },
+      "require": {
+        "@convex-dev/component-source": "./src/react-native/index.ts",
+        "types": "./dist/commonjs/react-native/index.d.ts",
+        "default": "./dist/commonjs/react-native/index.js"
+      }
+    },
     "./facepile": {
       "import": {
         "@convex-dev/component-source": "./src/facepile/index.tsx",
@@ -81,14 +96,25 @@
   },
   "peerDependencies": {
     "convex": ">=1.24.8 <1.35.0",
+    "expo-crypto": ">=14.1.0",
     "react": "~18.3.1 || ^19.0.0",
-    "react-dom": "~18.3.1 || ^19.0.0"
+    "react-dom": "~18.3.1 || ^19.0.0",
+    "react-native": ">=0.79.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "expo-crypto": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
     "@types/node": "^18.17.0",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
+    "@types/react-native": "^0.72.8",
     "eslint": "^9.9.1",
     "globals": "^16.2.0",
     "prettier": "^3.5.3",

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -1,0 +1,123 @@
+import { useQuery, useMutation, useConvex } from "convex/react";
+import { type FunctionReference } from "convex/server";
+import * as Crypto from "expo-crypto";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppState } from "react-native";
+
+import useSingleFlight from "../react/useSingleFlight.js";
+
+export type PresenceAPI = {
+  list: FunctionReference<"query", "public", { roomToken: string }, PresenceState[]>;
+  heartbeat: FunctionReference<
+    "mutation",
+    "public",
+    { roomId: string; userId: string; sessionId: string; interval: number },
+    { roomToken: string; sessionToken: string }
+  >;
+  disconnect: FunctionReference<"mutation", "public", { sessionToken: string }>;
+};
+
+// Presence state for a user within the given room.
+export type PresenceState = {
+  userId: string;
+  online: boolean;
+  lastDisconnected: number;
+};
+
+export function usePresence(
+  presence: PresenceAPI,
+  roomId: string,
+  userId: string,
+  interval: number = 10000,
+  convexUrl?: string
+) {
+  const convex = useConvex();
+  const baseUrl = convexUrl ?? convex.url;
+
+  const [sessionId, setSessionId] = useState(() => Crypto.randomUUID());
+  const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const [roomToken, setRoomToken] = useState<string | null>(null);
+
+  const sessionTokenRef = useRef<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const heartbeat = useSingleFlight(useMutation(presence.heartbeat));
+  const disconnect = useSingleFlight(useMutation(presence.disconnect));
+
+  const sendHeartbeat = useCallback(async () => {
+    const result = await heartbeat({ roomId, userId, sessionId, interval });
+    setRoomToken(result.roomToken);
+    setSessionToken(result.sessionToken);
+  }, [heartbeat, interval, roomId, sessionId, userId]);
+
+  const fireAndForgetDisconnect = useCallback(
+    (token: string) => {
+      fetch(`${baseUrl}/api/mutation`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: "presence:disconnect", args: { sessionToken: token } }),
+      }).catch(() => {});
+    },
+    [baseUrl]
+  );
+
+  // Reset session when roomId/userId changes
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    if (sessionTokenRef.current) {
+      disconnect({ sessionToken: sessionTokenRef.current });
+    }
+
+    setSessionId(Crypto.randomUUID());
+    setSessionToken(null);
+    setRoomToken(null);
+  }, [roomId, userId, disconnect]);
+
+  useEffect(() => {
+    sessionTokenRef.current = sessionToken;
+  }, [sessionToken]);
+
+  useEffect(() => {
+    // initial heartbeat + interval
+    void sendHeartbeat();
+    intervalRef.current = setInterval(sendHeartbeat, interval);
+
+    // handle app state changes instead of beforeunload/visibility
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "background") {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        if (sessionTokenRef.current) fireAndForgetDisconnect(sessionTokenRef.current);
+      } else if (state === "active") {
+        void sendHeartbeat();
+        intervalRef.current = setInterval(sendHeartbeat, interval);
+      }
+    });
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+
+      subscription.remove();
+
+      if (sessionTokenRef.current) {
+        fireAndForgetDisconnect(sessionTokenRef.current);
+      }
+    };
+  }, [roomId, userId, interval, sendHeartbeat, fireAndForgetDisconnect]);
+
+  const state = useQuery(presence.list, roomToken ? { roomToken } : "skip");
+
+  return useMemo(
+    () =>
+      state?.slice().sort((a, b) => {
+        if (a.userId === userId) return -1;
+        if (b.userId === userId) return 1;
+        return 0;
+      }),
+    [state, userId]
+  );
+}

--- a/src/types/expo-crypto/index.d.ts
+++ b/src/types/expo-crypto/index.d.ts
@@ -1,0 +1,3 @@
+declare module "expo-crypto" {
+  export function randomUUID(): string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Motivation
The `usePresence` hook exported from the `react` namespace is using web-only APIs (such as `crypto`, `navigator`, `window.addEventListener`, ...). As such, the hook is incompatible with React Native. Since react native exposes similar APIs via different tools/mechanisms, it's fairly easy to create a version of the hook that's compatible with react native.

## Description
 This PR adds React Native support by providing an additional `usePresence` hook under the `react-native` namespace, that uses RN compatible APIs

Specifically, it:
- replaces the usage of `crypto.randomUUID()` (which is a web-only API) with `expo-crypto`'s `Crypto.randomUUID()`
- replaces the usage of `navigator.sendBeacon()` (which is a we-only API) with custom implementation of "fire and forget" function
- replaces the `window.addEventListener` with `AppState.addEventListener` to achieve similar (same) "disconnect/reconnect on window focus" functionality

The rest of the functionality / APIs are kept 1:1 with the web version.

The `react-native` and `expo-crypto` dependecies are marked as optional peer dependencies to not pollute web-based projects.

You can see a working example and integration of this code here: https://github.com/zigcccc/petka-app/blob/main/src/hooks/presence/usePresence.ts

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
