### PR TITLE
Reduce heartbeat OCC contention (debounce timeout + snapshot presence read)

### DIFF
--- a/example/convex/presence.test.ts
+++ b/example/convex/presence.test.ts
@@ -1,0 +1,141 @@
+/// <reference types="vite/client" />
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { api } from "./_generated/api";
+import { initConvexTest } from "./setup.test";
+
+const ROOM = "room-1";
+const USER = "user-1";
+
+describe("presence heartbeat / timeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("graceful disconnect marks the user offline immediately", async () => {
+    const t = initConvexTest();
+    const { roomToken, sessionToken } = await t.mutation(
+      api.presence.heartbeat,
+      { roomId: ROOM, userId: USER, sessionId: "s1", interval: 10000 },
+    );
+    await t.mutation(api.presence.disconnect, { sessionToken });
+    const list = await t.query(api.presence.list, { roomToken });
+    expect(list).toMatchObject([{ userId: USER, online: false }]);
+  });
+
+  // Continued heartbeats keep the disconnect timeout pushed out (without
+  // rescheduling on every beat), so the user stays online across several
+  // timeout windows as long as heartbeats continue.
+  test("continued heartbeats keep the user online across timeout windows", async () => {
+    vi.useFakeTimers();
+    const t = initConvexTest();
+    const interval = 1000; // disconnect window = 2.5 * interval = 2500ms
+
+    const { roomToken } = await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      // Advance toward the armed deadline, then heartbeat — the debounced
+      // re-arm pushes the timeout out before it can fire for a live session.
+      vi.advanceTimersByTime(interval);
+      await t.finishInProgressScheduledFunctions();
+      await t.mutation(api.presence.heartbeat, {
+        roomId: ROOM,
+        userId: USER,
+        sessionId: "s1",
+        interval,
+      });
+    }
+
+    const list = await t.query(api.presence.list, { roomToken });
+    expect(list).toMatchObject([{ userId: USER, online: true }]);
+  });
+
+  test("a silent session is reaped after the timeout window", async () => {
+    vi.useFakeTimers();
+    const t = initConvexTest();
+    const interval = 1000; // window = 2500ms
+
+    const { roomToken } = await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval,
+    });
+
+    // No further heartbeats: advance past the 2.5x window so the armed
+    // disconnect timeout fires and marks the session offline.
+    vi.advanceTimersByTime(interval * 3);
+    await t.finishInProgressScheduledFunctions();
+
+    const list = await t.query(api.presence.list, { roomToken });
+    expect(list).toMatchObject([{ userId: USER, online: false }]);
+  });
+
+  // Shrinking the interval must bring the disconnect deadline forward: a
+  // session armed on a long interval, then heartbeating on a short one, should
+  // be reaped on the short window — not left online until the original deadline.
+  test("a shorter interval brings the disconnect deadline forward", async () => {
+    vi.useFakeTimers();
+    const t = initConvexTest();
+
+    const { roomToken } = await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval: 10000, // window = 25000ms
+    });
+    await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval: 1000, // window = 2500ms
+    });
+
+    // Advance past the short window but well short of the original long one.
+    vi.advanceTimersByTime(3000);
+    await t.finishInProgressScheduledFunctions();
+
+    const list = await t.query(api.presence.list, { roomToken });
+    expect(list).toMatchObject([{ userId: USER, online: false }]);
+  });
+
+  test("one of two sessions timing out keeps the user online", async () => {
+    vi.useFakeTimers();
+    const t = initConvexTest();
+    const interval = 1000;
+
+    const { roomToken } = await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval,
+    });
+    await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s2",
+      interval,
+    });
+
+    // Keep s2 alive while s1 goes silent: heartbeat s2 every interval and let
+    // time march past s1's window.
+    for (let i = 0; i < 6; i++) {
+      vi.advanceTimersByTime(interval);
+      await t.finishInProgressScheduledFunctions();
+      await t.mutation(api.presence.heartbeat, {
+        roomId: ROOM,
+        userId: USER,
+        sessionId: "s2",
+        interval,
+      });
+    }
+
+    // s1 should have been reaped, but the user stays online because s2 is live.
+    const list = await t.query(api.presence.list, { roomToken });
+    expect(list).toMatchObject([{ userId: USER, online: true }]);
+  });
+});

--- a/example/convex/presence.test.ts
+++ b/example/convex/presence.test.ts
@@ -22,6 +22,30 @@ describe("presence heartbeat / timeout", () => {
     expect(list).toMatchObject([{ userId: USER, online: false }]);
   });
 
+  // Exercises the snapshot fast-path's fallback: when the snapshot says the user
+  // is not online, the heartbeat takes a tracked read and flips them back online.
+  test("a heartbeat after disconnect brings the user back online", async () => {
+    const t = initConvexTest();
+    const first = await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval: 10000,
+    });
+    await t.mutation(api.presence.disconnect, {
+      sessionToken: first.sessionToken,
+    });
+
+    const { roomToken } = await t.mutation(api.presence.heartbeat, {
+      roomId: ROOM,
+      userId: USER,
+      sessionId: "s1",
+      interval: 10000,
+    });
+    const list = await t.query(api.presence.list, { roomToken });
+    expect(list).toMatchObject([{ userId: USER, online: true }]);
+  });
+
   // Continued heartbeats keep the disconnect timeout pushed out (without
   // rescheduling on every beat), so the user stays online across several
   // timeout windows as long as heartbeats continue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "@typescript-eslint/parser": "^8.46.2",
         "@vitejs/plugin-react": "^5.1.0",
         "chokidar-cli": "3.0.0",
-        "convex": "1.35.1",
-        "convex-test": "^0.0.38",
+        "convex": "1.36.0",
+        "convex-test": "^0.0.53",
         "eslint": "^9.38.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -37,7 +37,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "convex": "^1.24.8",
+        "convex": "^1.36.0",
         "expo-crypto": ">=14.1.0",
         "react": "~18.3.1 || ^19.0.0",
         "react-dom": "~18.3.1 || ^19.0.0",
@@ -2186,9 +2186,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,9 +2200,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,9 +2214,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2237,9 +2228,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2254,9 +2242,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,9 +2256,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2288,9 +2270,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2305,9 +2284,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,9 +2298,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,9 +2312,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,9 +2326,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,9 +2340,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2390,9 +2354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3985,9 +3946,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
-      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.0.tgz",
+      "integrity": "sha512-17cfDr2z+Apd59291rKWij6jq79eVwzY9u2MQOnuVkOsfEPXcuerWHQLf1ngXAbQjeTXD1nwQYsxQBhZnjZMIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4024,13 +3985,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.38.tgz",
-      "integrity": "sha512-1o/3GvUR9gMLjiqq7SxchI/0OYQaWwbQC4INmB1SNt1WLBjUgEM8+brgpqrZwJ+Vb1DdGZokCVeihwT5IPk49w==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.53.tgz",
+      "integrity": "sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.16.4"
+        "convex": "^1.32.0"
       }
     },
     "node_modules/convex/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     }
   },
   "peerDependencies": {
-    "convex": "^1.24.8",
+    "convex": "^1.36.0",
     "expo-crypto": ">=14.1.0",
     "react": "~18.3.1 || ^19.0.0",
     "react-dom": "~18.3.1 || ^19.0.0",
@@ -102,8 +102,8 @@
     "@typescript-eslint/parser": "^8.46.2",
     "@vitejs/plugin-react": "^5.1.0",
     "chokidar-cli": "3.0.0",
-    "convex": "1.35.1",
-    "convex-test": "^0.0.38",
+    "convex": "1.36.0",
+    "convex-test": "^0.0.53",
     "eslint": "^9.38.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -5,8 +5,19 @@
 // can be used in Convex server functions.
 
 import { v } from "convex/values";
-import { mutation, query, type QueryCtx } from "./_generated/server.js";
-import { api } from "./_generated/api.js";
+import {
+  type MutationCtx,
+  type QueryCtx,
+  internalMutation,
+  mutation,
+  query,
+} from "./_generated/server.js";
+import { internal } from "./_generated/api.js";
+import type { Doc } from "./_generated/dataModel.js";
+
+// A session is disconnected once this many heartbeat intervals elapse with no
+// heartbeat (the disconnect timeout fires).
+const TIMEOUT_INTERVAL_MULTIPLIER = 2.5;
 
 export const heartbeat = mutation({
   args: {
@@ -20,7 +31,11 @@ export const heartbeat = mutation({
     sessionToken: v.string(),
   }),
   handler: async (ctx, { roomId, userId, sessionId, interval = 10000 }) => {
-    // Update or create session
+    const now = Date.now();
+
+    // Update or create the session. No per-beat write in the steady state: an
+    // existing session for the same room/user is left untouched here (the
+    // disconnect timeout below is what gets pushed out).
     const session = await ctx.db
       .query("sessions")
       .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
@@ -49,16 +64,6 @@ export const heartbeat = mutation({
       });
     }
 
-    // Cancel any existing timeout for session.
-    const existingTimeout = await ctx.db
-      .query("sessionTimeouts")
-      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
-      .unique();
-    if (existingTimeout) {
-      await ctx.scheduler.cancel(existingTimeout.scheduledFunctionId);
-      await ctx.db.delete("sessionTimeouts", existingTimeout._id);
-    }
-
     // Generate token to list room presence.
     let roomToken: string;
     const roomTokenRecord = await ctx.db
@@ -85,20 +90,84 @@ export const heartbeat = mutation({
       await ctx.db.insert("sessionTokens", { sessionId, token: sessionToken });
     }
 
-    // Schedule timeout heartbeat for 2.5x heartbeat period.
-    const timeout = await ctx.scheduler.runAfter(
-      interval * 2.5,
-      api.public.disconnect,
-      {
-        sessionToken: sessionToken,
-      },
-    );
-    await ctx.db.insert("sessionTimeouts", {
-      sessionId,
-      scheduledFunctionId: timeout,
-    });
+    // Maintain a single disconnect timeout for this session, scheduled to fire
+    // `window` ahead. To keep the steady-state heartbeat cheap we do NOT
+    // reschedule on every beat: the armed timeout is only pushed out when it is
+    // getting close to firing — within a jittered fraction of the interval, so
+    // concurrent sessions don't all reschedule on the same beat — or when a
+    // shrunk interval needs it to fire sooner. Rescheduling updates the row in
+    // place rather than deleting and re-inserting. The timeout itself rarely
+    // runs: a graceful disconnect (sendBeacon on unload) cancels it first.
+    const window = interval * TIMEOUT_INTERVAL_MULTIPLIER;
+    const deadline = now + window;
+    const existingTimeout = await ctx.db
+      .query("sessionTimeouts")
+      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+      .first();
+    if (!existingTimeout) {
+      const scheduledFunctionId = await ctx.scheduler.runAfter(
+        window,
+        internal.public.disconnectStaleSession,
+        { sessionId },
+      );
+      await ctx.db.insert("sessionTimeouts", {
+        sessionId,
+        scheduledFunctionId,
+        deadline,
+      });
+    } else {
+      const armedDeadline = existingTimeout.deadline ?? 0;
+      // Re-arm when the timeout is within ~1–1.5 intervals of firing (jittered,
+      // so concurrent sessions don't all reschedule on the same beat), or when
+      // the new window would fire sooner than what's armed. The lower bound of
+      // one full interval guarantees a heartbeat lands inside the re-arm window
+      // before the timeout could fire for a live session.
+      const rearmWithin = interval * (1 + Math.random() * 0.5);
+      if (armedDeadline - now <= rearmWithin || deadline < armedDeadline) {
+        await ctx.scheduler.cancel(existingTimeout.scheduledFunctionId);
+        const scheduledFunctionId = await ctx.scheduler.runAfter(
+          window,
+          internal.public.disconnectStaleSession,
+          { sessionId },
+        );
+        await ctx.db.patch("sessionTimeouts", existingTimeout._id, {
+          scheduledFunctionId,
+          deadline,
+        });
+      }
+    }
 
     return { roomToken, sessionToken: sessionToken };
+  },
+});
+
+// The session's disconnect timeout, armed (and pushed out) by `heartbeat`. It
+// fires only when heartbeats stop without a graceful disconnect — in the common
+// case the sendBeacon `disconnect` on unload cancels it first. Unlike graceful
+// `disconnect`, it must not cancel its own scheduled function (it is the one
+// running), so it passes `cancelScheduled: false`.
+export const disconnectStaleSession = internalMutation({
+  args: { sessionId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { sessionId }) => {
+    const session = await ctx.db
+      .query("sessions")
+      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+      .unique();
+    if (!session) {
+      // Already gone (e.g. graceful disconnect raced us). Clear any stray
+      // timeout row so it can't strand a future session.
+      const timeouts = await ctx.db
+        .query("sessionTimeouts")
+        .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+        .collect();
+      for (const timeout of timeouts) {
+        await ctx.db.delete("sessionTimeouts", timeout._id);
+      }
+      return null;
+    }
+    await removeSession(ctx, session, { cancelScheduled: false });
+    return null;
   },
 });
 
@@ -242,10 +311,8 @@ export const disconnect = mutation({
     if (!sessionTokenRecord) {
       return;
     }
-    await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
     const { sessionId } = sessionTokenRecord;
 
-    // Remove the session
     const session = await ctx.db
       .query("sessions")
       .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
@@ -256,47 +323,67 @@ export const disconnect = mutation({
         sessionToken,
         "without a session",
       );
+      // Still clear the orphaned token.
+      await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
       return;
     }
 
-    const { roomId, userId } = session;
-    await ctx.db.delete("sessions", session._id);
+    // Graceful disconnect cancels the still-pending timeout (it isn't firing us).
+    await removeSession(ctx, session, { cancelScheduled: true });
+  },
+});
 
-    const userPresence = await getUserPresence(ctx, userId, roomId);
-    if (!userPresence) {
-      console.error(
-        "Should not have a session token",
-        sessionToken,
-        "without a user presence",
-      );
-      return;
-    }
+// Remove a session and its satellite rows (disconnect token and timeout),
+// marking the user offline when it was their last session in the room. Shared
+// by graceful `disconnect` (cancelScheduled: true) and the
+// `disconnectStaleSession` timeout (cancelScheduled: false — the job firing it
+// is already running, so there is nothing to cancel).
+async function removeSession(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+  { cancelScheduled }: { cancelScheduled: boolean },
+) {
+  const { roomId, userId, sessionId } = session;
+  await ctx.db.delete("sessions", session._id);
 
-    // Mark user offline if they don't have any remaining sessions.
-    const remainingSessions = await ctx.db
+  const sessionTokenRecord = await ctx.db
+    .query("sessionTokens")
+    .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+    .unique();
+  if (sessionTokenRecord) {
+    await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
+  }
+
+  // Mark user offline if they don't have any remaining sessions.
+  const userPresence = await getUserPresence(ctx, userId, roomId);
+  if (userPresence?.online) {
+    const remainingSession = await ctx.db
       .query("sessions")
       .withIndex("room_user_session", (q) =>
         q.eq("roomId", roomId).eq("userId", userId),
       )
-      .collect();
-    if (userPresence.online && remainingSessions.length === 0) {
+      .first();
+    if (!remainingSession) {
       await ctx.db.patch("presence", userPresence._id, {
         online: false,
         lastDisconnected: Date.now(),
       });
     }
+  }
 
-    // Cancel timeout for this session.
-    const timeout = await ctx.db
-      .query("sessionTimeouts")
-      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
-      .unique();
-    if (timeout) {
+  // Clear the session's disconnect timeout(s). Normally there is exactly one;
+  // collect to also clear any stray duplicate rather than throwing.
+  const timeouts = await ctx.db
+    .query("sessionTimeouts")
+    .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+    .collect();
+  for (const timeout of timeouts) {
+    if (cancelScheduled) {
       await ctx.scheduler.cancel(timeout.scheduledFunctionId);
-      await ctx.db.delete("sessionTimeouts", timeout._id);
     }
-  },
-});
+    await ctx.db.delete("sessionTimeouts", timeout._id);
+  }
+}
 
 export const updateRoomUser = mutation({
   args: {

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -9,6 +9,7 @@ import {
   type MutationCtx,
   type QueryCtx,
   internalMutation,
+  internalQuery,
   mutation,
   query,
 } from "./_generated/server.js";
@@ -49,19 +50,34 @@ export const heartbeat = mutation({
     }
 
     // Set user online if needed.
-    const userPresence = await getUserPresence(ctx, userId, roomId);
-    if (!userPresence) {
-      await ctx.db.insert("presence", {
-        roomId,
-        userId,
-        online: true,
-        lastDisconnected: 0,
-      });
-    } else if (!userPresence.online) {
-      await ctx.db.patch("presence", userPresence._id, {
-        online: true,
-        lastDisconnected: 0,
-      });
+    //
+    // Fast path: check whether the user is already online via a *snapshot*
+    // query, which does not add the shared per-user presence row to this
+    // mutation's read set. Reading that row directly here is the main source of
+    // heartbeat OCC contention, because a concurrent `disconnect` writes it. In
+    // the overwhelmingly common case (already online) we then do nothing, taking
+    // no dependency on it at all.
+    //
+    // Only when we are not already online do we fall back to a tracked read and
+    // create/patch the row under normal OCC protection — the snapshot result
+    // alone must never drive the write, or two concurrent first beats could both
+    // insert a presence row and break the `getUserPresence` uniqueness.
+    const alreadyOnline = await runSnapshotQuery(ctx, { userId, roomId });
+    if (!alreadyOnline) {
+      const userPresence = await getUserPresence(ctx, userId, roomId);
+      if (!userPresence) {
+        await ctx.db.insert("presence", {
+          roomId,
+          userId,
+          online: true,
+          lastDisconnected: 0,
+        });
+      } else if (!userPresence.online) {
+        await ctx.db.patch("presence", userPresence._id, {
+          online: true,
+          lastDisconnected: 0,
+        });
+      }
     }
 
     // Generate token to list room presence.
@@ -510,6 +526,39 @@ async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
         q.eq("userId", userId).eq("online", false).eq("roomId", roomId),
       )
       .unique())
+  );
+}
+
+// Whether the user is currently online in the room. Read by `heartbeat` via a
+// snapshot query (see `runSnapshotQuery`) so the read does not enter the
+// heartbeat's read set.
+export const userPresenceOnline = internalQuery({
+  args: { userId: v.string(), roomId: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, { userId, roomId }) => {
+    const presence = await getUserPresence(ctx, userId, roomId);
+    return presence?.online === true;
+  },
+});
+
+// `ctx.runSnapshotQuery` runs a query without recording its reads in the calling
+// mutation's read set, so OCC won't retry the mutation when the queried rows
+// change concurrently. It isn't in the generated `MutationCtx` type yet, so we
+// narrow `ctx` to just the method we use.
+type SnapshotQueryCtx = {
+  runSnapshotQuery: (
+    ref: typeof internal.public.userPresenceOnline,
+    args: { userId: string; roomId: string },
+  ) => Promise<boolean>;
+};
+
+function runSnapshotQuery(
+  ctx: MutationCtx,
+  args: { userId: string; roomId: string },
+): Promise<boolean> {
+  return (ctx as MutationCtx & SnapshotQueryCtx).runSnapshotQuery(
+    internal.public.userPresenceOnline,
+    args,
   );
 }
 

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -43,5 +43,11 @@ export default defineSchema({
   sessionTimeouts: defineTable({
     sessionId: v.string(),
     scheduledFunctionId: v.id("_scheduled_functions"),
+    // Wall-clock time (ms) the armed `scheduledFunctionId` is expected to fire.
+    // Lets a heartbeat decide — without touching the scheduler — whether the
+    // armed timeout is close enough to firing to be worth pushing out, so most
+    // heartbeats can skip rescheduling entirely. Optional for backward
+    // compatibility with rows created before this field existed.
+    deadline: v.optional(v.number()),
   }).index("sessionId", ["sessionId"]),
 });


### PR DESCRIPTION
Two changes that cut OCC contention from `heartbeat` under multi-session load.
Each is a separate commit and stands on its own.

## 1. Debounce the disconnect-timeout reschedule

`heartbeat` rescheduled the session disconnect timeout on **every** call: cancel
the pending scheduled function → delete its `sessionTimeouts` row → schedule a
fresh disconnect → insert a new row — all to keep pushing out a timeout that, in
the common case, never fires (the sendBeacon `disconnect` on unload cancels it).

Now debounced so the steady-state heartbeat does **no** scheduler work and no
`sessionTimeouts` write:

- `sessionTimeouts` rows store the armed `deadline`. A heartbeat reschedules only
  when the timeout is close to firing (within a jittered ~1–1.5 intervals, so
  concurrent sessions don't reschedule on the same beat) or when a **shrunk
  interval** needs it sooner. Reschedule updates the row in place (`patch`).
- The timeout fires a small internal `disconnectStaleSession` that shares removal
  logic with graceful `disconnect` via a `removeSession` helper — split out so
  the timeout doesn't cancel its own running scheduled function.
- The `sessions` table is intentionally left unchanged (no per-beat field
  writes).

Hardening: `sessionTimeouts` lookups use `.first()` / collect-and-delete so a
stray duplicate degrades gracefully; the "any sessions left?" check uses
`.first()`.

## 2. Read presence via a snapshot query

Even with the reschedule debounced, every heartbeat still read the shared
per-user presence row to decide whether to set the user online — putting that row
in the heartbeat's read set, where a concurrent `disconnect` write conflicts with
it. This is the dominant source of heartbeat OCC retries.

The heartbeat now reads it with `ctx.runSnapshotQuery` (a new internal
`userPresenceOnline` query), which does **not** record the read in the mutation's
read set. In the common case (already online) the heartbeat does nothing and
takes no dependency on the presence row. Only when not already online does it
fall back to a tracked `getUserPresence` read + insert/patch under normal OCC
protection — the snapshot result never drives the write directly (otherwise two
concurrent first beats could both insert a presence row and break uniqueness).

**Compatibility:** `runSnapshotQuery` was added in **convex 1.36.0**, so the peer
floor moves from `^1.24.8` to `^1.36.0`. Dev/test deps move to convex 1.36.0 and
convex-test 0.0.53 (first to support the `snapshotQuery` udf type). It's also not
in the generated `MutationCtx` type yet, so a small local helper narrows `ctx`.

## Tests

`example/convex/presence.test.ts`: graceful disconnect → offline, the snapshot
fallback bringing a user back online after disconnect, disconnect-after-silence,
the debounced keep-alive across multiple timeout windows, interval-shrink
bringing the disconnect forward, and multi-session liveness. `npm test`,
`npm run typecheck`, and `npm run lint` pass.