### PR TITLE
usePresence: optional cross-tab coordination (one heartbeat per user)

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, useConvex } from "convex/react";
 import type { FunctionReference } from "convex/server";
 import useSingleFlight from "./useSingleFlight.js";
+import useTabLeader, { hasOtherContenders } from "./useTabLeader.js";
 
 // Interface in your Convex app /convex directory that implements these
 // functions by calling into the presence component, e.g., like this:
@@ -61,6 +62,21 @@ export interface PresenceState {
   image?: string;
 }
 
+// Options for `usePresence`.
+export interface UsePresenceOptions {
+  // Coordinate across browser tabs so that only one *visible* tab heartbeats on
+  // behalf of the user, using Web Locks leader election. This collapses N open
+  // tabs into a single session + heartbeat stream, avoiding the database
+  // contention that independent per-tab heartbeats cause. The user is considered
+  // present while at least one tab is visible; presence is handed between tabs
+  // as they are shown/hidden/closed.
+  //
+  // Defaults to false, preserving the original behavior where every visible tab
+  // heartbeats on its own. Falls back to that behavior automatically where the
+  // Web Locks API is unavailable.
+  coordinateTabs?: boolean;
+}
+
 // React hook for maintaining presence state.
 //
 // This hook is designed to be efficient and only sends a message to users
@@ -75,6 +91,7 @@ export default function usePresence(
   userId: string,
   interval: number = 10000,
   convexUrl?: string,
+  options?: UsePresenceOptions,
 ): PresenceState[] | undefined {
   const hasMounted = useRef(false);
   const convex = useConvex();
@@ -92,6 +109,33 @@ export default function usePresence(
 
   const heartbeat = useSingleFlight(useMutation(presence.heartbeat));
   const disconnect = useSingleFlight(useMutation(presence.disconnect));
+
+  // Tab coordination. Only enabled when requested and supported; otherwise this
+  // collapses to the original per-tab behavior (`active` === `visible`).
+  const canCoordinate =
+    (options?.coordinateTabs ?? false) &&
+    typeof navigator !== "undefined" &&
+    !!navigator.locks;
+  const lockName = `convex-presence-leader:${roomId}:${userId}`;
+
+  // Track whether this tab is visible.
+  const [visible, setVisible] = useState(
+    () => typeof document === "undefined" || !document.hidden,
+  );
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onChange = () => setVisible(!document.hidden);
+    document.addEventListener("visibilitychange", onChange);
+    return () => document.removeEventListener("visibilitychange", onChange);
+  }, []);
+
+  // Contend for leadership only while visible (so presence reflects "any visible
+  // tab"). The leader is the single tab that heartbeats.
+  const isLeader = useTabLeader(lockName, canCoordinate && visible);
+
+  // This tab heartbeats when it is the visible leader (coordinating) or simply
+  // while it is visible (not coordinating — the original per-tab behavior).
+  const active = canCoordinate ? isLeader : visible;
 
   useEffect(() => {
     // Reset session state when roomId or userId changes.
@@ -114,24 +158,25 @@ export default function usePresence(
   }, [sessionToken, roomToken]);
 
   useEffect(() => {
-    // Periodic heartbeats.
+    // Heartbeat while this tab is the active presence owner.
+    if (!active) return;
+
     const sendHeartbeat = async () => {
       const result = await heartbeat({ roomId, userId, sessionId, interval });
       setRoomToken(result.roomToken);
       setSessionToken(result.sessionToken);
     };
 
-    // Send initial heartbeat
     void sendHeartbeat();
+    const id = setInterval(() => void sendHeartbeat(), interval);
+    intervalRef.current = id;
 
-    // Clear any existing interval before setting a new one
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    intervalRef.current = setInterval(sendHeartbeat, interval);
-
-    // Handle page unload.
+    // On page unload without coordination, beacon a disconnect (the original
+    // behavior). When coordinating we let the browser release the Web Lock — a
+    // waiting tab takes over, or the server-side timeout marks the last tab
+    // offline — so no beacon is needed.
     const handleUnload = () => {
+      if (canCoordinate) return;
       if (sessionTokenRef.current) {
         const blob = new Blob(
           [
@@ -140,53 +185,52 @@ export default function usePresence(
               args: { sessionToken: sessionTokenRef.current },
             }),
           ],
-          {
-            type: "application/json",
-          },
+          { type: "application/json" },
         );
         navigator.sendBeacon(`${baseUrl}/api/mutation`, blob);
       }
     };
     window.addEventListener("beforeunload", handleUnload);
 
-    // Handle visibility changes.
-    const handleVisibility = async () => {
-      if (document.hidden) {
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
-        if (sessionTokenRef.current) {
-          await disconnect({ sessionToken: sessionTokenRef.current });
-        }
-      } else {
-        void sendHeartbeat();
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-        }
-        intervalRef.current = setInterval(sendHeartbeat, interval);
-      }
-    };
-    const wrappedHandleVisibility = () => {
-      handleVisibility().catch(console.error);
-    };
-    document.addEventListener("visibilitychange", wrappedHandleVisibility);
-
-    // Cleanup.
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+      clearInterval(id);
+      if (intervalRef.current === id) {
+        intervalRef.current = null;
       }
-      document.removeEventListener("visibilitychange", wrappedHandleVisibility);
       window.removeEventListener("beforeunload", handleUnload);
-      // Don't disconnect on first render in strict mode.
-      if (hasMounted.current) {
-        if (sessionTokenRef.current) {
-          void disconnect({ sessionToken: sessionTokenRef.current });
-        }
+
+      const token = sessionTokenRef.current;
+      // Don't disconnect on the throwaway first cleanup in strict mode.
+      if (!token || !hasMounted.current) return;
+
+      if (!canCoordinate) {
+        // Per-tab behavior: disconnect whenever this tab stops being active
+        // (hidden or unmounted).
+        void disconnect({ sessionToken: token });
+        return;
       }
+      // Coordinating: this tab is stepping down as leader. Disconnect only if no
+      // other tab is waiting to take over (we were the last visible tab).
+      // Otherwise hand off silently — the next leader keeps the user online and
+      // this tab's now-orphaned session is reaped by the server-side timeout.
+      void hasOtherContenders(lockName).then((others) => {
+        if (!others) {
+          void disconnect({ sessionToken: token });
+        }
+      });
     };
-  }, [heartbeat, disconnect, roomId, userId, baseUrl, interval, sessionId]);
+  }, [
+    active,
+    heartbeat,
+    disconnect,
+    roomId,
+    userId,
+    sessionId,
+    interval,
+    baseUrl,
+    canCoordinate,
+    lockName,
+  ]);
 
   useEffect(() => {
     hasMounted.current = true;

--- a/src/react/useTabLeader.ts
+++ b/src/react/useTabLeader.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Cross-tab leader election via the Web Locks API.
+ *
+ * While `enabled` is true this tab contends for an origin-wide lock named
+ * `name`. Exactly one contending tab holds the lock at a time and is the
+ * "leader" — this hook returns `true` in that tab and `false` in the others.
+ * When the leader stops contending (`enabled` flips to false, the component
+ * unmounts, or the tab closes/crashes) the lock is released and another
+ * contending tab becomes the leader.
+ *
+ * Where the Web Locks API is unavailable, every enabled tab reports itself as
+ * leader so callers degrade to uncoordinated per-tab behavior rather than going
+ * silent.
+ */
+export default function useTabLeader(name: string, enabled: boolean): boolean {
+  const [isLeader, setIsLeader] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsLeader(false);
+      return;
+    }
+
+    const locks =
+      typeof navigator !== "undefined" ? navigator.locks : undefined;
+    if (!locks) {
+      // No Web Locks support: fall back to "every tab leads".
+      setIsLeader(true);
+      return;
+    }
+
+    const controller = new AbortController();
+    let releaseLock: (() => void) | undefined;
+
+    locks
+      .request(name, { signal: controller.signal }, () => {
+        setIsLeader(true);
+        // Hold the lock until this effect tears down. Resolving the returned
+        // promise releases the lock and hands leadership to the next waiter.
+        return new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        });
+      })
+      .catch((error: unknown) => {
+        // The request is aborted (AbortError) when we stop contending before
+        // acquiring the lock — expected, not a failure.
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          console.error("[presence] tab leader lock error", error);
+        }
+      });
+
+    return () => {
+      setIsLeader(false);
+      controller.abort();
+      releaseLock?.();
+    };
+  }, [name, enabled]);
+
+  return isLeader;
+}
+
+/**
+ * Whether any tab other than this one currently holds or is waiting on the lock
+ * `name`. Used by the leader to decide, as it steps down, whether another tab is
+ * ready to take over (so it can hand off silently) or it is the last one (so it
+ * should disconnect). Returns false where the Web Locks query API is missing.
+ */
+export async function hasOtherContenders(name: string): Promise<boolean> {
+  const locks =
+    typeof navigator !== "undefined" ? navigator.locks : undefined;
+  if (!locks?.query) {
+    return false;
+  }
+  try {
+    const { held = [], pending = [] } = await locks.query();
+    const count = [...held, ...pending].filter(
+      (lock) => lock.name === name,
+    ).length;
+    // This tab holds one lock for `name`; anything beyond that is another tab.
+    return count > 1;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

Each browser tab runs its own `usePresence` with its own session id and
heartbeat loop. A user with several tabs open therefore produces N independent
heartbeat **and** disconnect streams, all reading/writing the same per-user
presence state. Under multi-tab load that's the main driver of database
contention — independent tabs racing on one user's presence row.

## Change

Add an opt-in **`coordinateTabs`** option to `usePresence` that elects a single
leader tab via the **Web Locks API**. Only the leader heartbeats; the other tabs
just keep their reactive `list` subscription. This collapses N tabs into **one
session + one heartbeat stream** per user.

Semantics: **present while any tab is visible.**

- Only *visible* tabs contend for the lock, so the leader is always a visible
  tab. When the leader is hidden/closed it releases the lock and a waiting
  visible tab takes over.
- When the **last** visible tab is hidden, the stepping-down leader checks via
  `navigator.locks.query()` that nobody else is waiting and then disconnects, so
  the user goes offline promptly. If another tab *is* waiting it hands off
  silently and stays online; the orphaned session is reaped by the server-side
  disconnect timeout.
- On tab *close* while coordinating we rely on the browser auto-releasing the
  lock (handoff) or the server timeout (last tab) instead of a `sendBeacon`.

**Backward compatible:** defaults to off (existing callers unchanged), and falls
back to the original per-tab behavior automatically where the Web Locks API is
unavailable (older browsers, non-browser environments; React Native is
single-instance so it's a no-op there).

Leader election is isolated in a small `useTabLeader` helper.

## API

```ts
usePresence(presence, roomId, userId, interval, convexUrl, { coordinateTabs: true });
```

## Validation status

Build, typecheck, and lint pass. The repo has no browser/hook test harness and
jsdom doesn't implement the Web Locks API, so the coordination path is **not yet
covered by automated tests** — it's been reasoned through but still needs manual
multi-tab validation in a real browser (leader handoff on show/hide/close,
last-tab offline, the no-locks fallback). Opening as a draft for that reason; I
can wire up a Playwright-style multi-context check if you'd like coverage before
merge.