### PR TITLE
patch instead of deleting timeout docs

### DIFF
--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -56,7 +56,6 @@ export const heartbeat = mutation({
       .unique();
     if (existingTimeout) {
       await ctx.scheduler.cancel(existingTimeout.scheduledFunctionId);
-      await ctx.db.delete("sessionTimeouts", existingTimeout._id);
     }
 
     // Generate token to list room presence.
@@ -94,10 +93,16 @@ export const heartbeat = mutation({
         scheduled: true,
       },
     );
-    await ctx.db.insert("sessionTimeouts", {
-      sessionId,
-      scheduledFunctionId: timeout,
-    });
+    if (existingTimeout) {
+      await ctx.db.patch("sessionTimeouts", existingTimeout._id, {
+        scheduledFunctionId: timeout,
+      });
+    } else {
+      await ctx.db.insert("sessionTimeouts", {
+        sessionId,
+        scheduledFunctionId: timeout,
+      });
+    }
 
     return { roomToken, sessionToken: sessionToken };
   },


### PR DESCRIPTION
I suspect it'll be cheaper / more efficient to do a patch vs. a delete & insert.

The query for a timeout for the session is indexed, but currently needs to walk all the tombstones, whereas a patch doesn't.