### PR TITLE
use a singleton worker to process disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.3-alpha.0
+
+- Replaces per-session scheduled disconnects with a deployment-wide batch
+  worker.
+
 ## 0.3.2
 
 - Patches instead of re-creating timeout documents for efficiency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.3-alpha.0
+## 0.4.0-alpha.0
 
 - Replaces per-session scheduled disconnects with a deployment-wide batch
   worker.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ list of users in a "room" including their status for when they were last online.
 
 It can be tricky to implement presence efficiently, without any polling and
 without re-running queries every time a user sends a heartbeat message. This
-component implements presence via Convex scheduled functions such that clients
-only receive updates when a user joins or leaves the room.
+component implements presence via a single deployment-wide worker (a
+[batch-worker](https://github.com/get-convex/batch-worker) loop) that sleeps
+until the next session timeout is due, such that clients only receive updates
+when a user joins or leaves the room and heartbeats don't schedule any work.
 
 The most common use case for this component is via the usePresence hook, which
 takes care of sending heartbeart messages to the server and gracefully

--- a/example/convex/presence.test.ts
+++ b/example/convex/presence.test.ts
@@ -1,0 +1,77 @@
+/// <reference types="vite/client" />
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { api } from "./_generated/api";
+import { initConvexTest } from "./setup.test.js";
+
+// The disconnect worker runs on scheduled functions inside the nested
+// batch-worker component, so these tests drive it with fake timers.
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const HEARTBEAT = {
+  roomId: "room1",
+  userId: "user1",
+  sessionId: "session1",
+  interval: 1000,
+};
+
+test("session times out and user goes offline without heartbeats", async () => {
+  const t = initConvexTest();
+  const { roomToken } = await t.mutation(api.presence.heartbeat, HEARTBEAT);
+
+  let users = await t.query(api.presence.list, { roomToken });
+  expect(users).toMatchObject([{ userId: "user1", online: true }]);
+
+  // Send no more heartbeats: the worker's loop wakes at the session deadline
+  // (2.5x the heartbeat interval) and marks the user offline.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+  users = await t.query(api.presence.list, { roomToken });
+  expect(users).toMatchObject([{ userId: "user1", online: false }]);
+  expect(users[0].lastDisconnected).toBeGreaterThan(0);
+});
+
+test("heartbeats keep the session alive", async () => {
+  const t = initConvexTest();
+  const { roomToken } = await t.mutation(api.presence.heartbeat, HEARTBEAT);
+
+  // Keep heartbeating past the original 2.5s deadline; the worker wakes at
+  // the stale deadline, finds nothing expired, and goes back to sleep.
+  for (let i = 0; i < 3; i++) {
+    vi.advanceTimersByTime(2000);
+    await t.finishInProgressScheduledFunctions();
+    await t.mutation(api.presence.heartbeat, HEARTBEAT);
+  }
+  const users = await t.query(api.presence.list, { roomToken });
+  expect(users).toMatchObject([{ userId: "user1", online: true }]);
+
+  // Then stop: the session times out.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  expect(await t.query(api.presence.list, { roomToken })).toMatchObject([
+    { userId: "user1", online: false },
+  ]);
+});
+
+test("graceful disconnect takes effect immediately", async () => {
+  const t = initConvexTest();
+  const { roomToken, sessionToken } = await t.mutation(
+    api.presence.heartbeat,
+    HEARTBEAT,
+  );
+
+  await t.mutation(api.presence.disconnect, { sessionToken });
+  expect(await t.query(api.presence.list, { roomToken })).toMatchObject([
+    { userId: "user1", online: false },
+  ]);
+
+  // The worker's loop still wakes at the now-deleted session's deadline,
+  // finds nothing to do, and goes idle without erroring.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  expect(await t.query(api.presence.list, { roomToken })).toMatchObject([
+    { userId: "user1", online: false },
+  ]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/presence",
-  "version": "0.3.2",
+  "version": "0.3.3-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/presence",
-      "version": "0.3.2",
+      "version": "0.3.3-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@convex-dev/batch-worker": "^0.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@convex-dev/presence",
       "version": "0.3.2",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@convex-dev/batch-worker": "^0.2.0"
+      },
       "devDependencies": {
         "@convex-dev/auth": "0.0.91",
         "@convex-dev/eslint-plugin": "^2.0.0",
@@ -21,8 +24,8 @@
         "@typescript-eslint/parser": "^8.46.2",
         "@vitejs/plugin-react": "^5.1.0",
         "chokidar-cli": "3.0.0",
-        "convex": "1.35.1",
-        "convex-test": "^0.0.38",
+        "convex": "1.41.0",
+        "convex-test": "^0.0.51",
         "eslint": "^9.38.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -37,7 +40,7 @@
         "vitest": "^4.0.0"
       },
       "peerDependencies": {
-        "convex": "^1.24.8",
+        "convex": "^1.36.1",
         "expo-crypto": ">=14.1.0",
         "react": "~18.3.1 || ^19.0.0",
         "react-dom": "~18.3.1 || ^19.0.0",
@@ -654,6 +657,16 @@
         }
       }
     },
+    "node_modules/@convex-dev/batch-worker": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.0.tgz",
+      "integrity": "sha512-dn0L/5jqufXHzgzAhWqjGBmDGXbwRA0S6YVV5Z66y4pMXZ+YL3M4aHCk9iBInPp5zOtEPgVbfo/BYMxhLxVP+w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.36.1",
+        "react": "^18.3.1 || ^19.0.0"
+      }
+    },
     "node_modules/@convex-dev/eslint-plugin": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@convex-dev/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
@@ -1248,7 +1261,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3924,15 +3936,14 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
-      "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
-      "dev": true,
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.41.0.tgz",
+      "integrity": "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.20.1"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -3944,7 +3955,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
-        "@clerk/react": "^6.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -3963,13 +3974,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.38.tgz",
-      "integrity": "sha512-1o/3GvUR9gMLjiqq7SxchI/0OYQaWwbQC4INmB1SNt1WLBjUgEM8+brgpqrZwJ+Vb1DdGZokCVeihwT5IPk49w==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.51.tgz",
+      "integrity": "sha512-J+4YRpKGXJDfnQqiWUUT+ylNmNO36MpkuwqG3JG4ld+7QtroZGF8HqO4qzMmfv5ltm71rPbkBvi//MoMHjnVvQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.16.4"
+        "convex": "^1.32.0"
       }
     },
     "node_modules/convex/node_modules/@esbuild/aix-ppc64": {
@@ -3979,7 +3990,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3996,7 +4006,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4013,7 +4022,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4030,7 +4038,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4047,7 +4054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4064,7 +4070,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4081,7 +4086,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4098,7 +4102,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4115,7 +4118,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4132,7 +4134,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4149,7 +4150,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4166,7 +4166,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4183,7 +4182,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4200,7 +4198,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4217,7 +4214,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4234,7 +4230,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4251,7 +4246,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4268,7 +4262,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4285,7 +4278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4302,7 +4294,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4319,7 +4310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4336,7 +4326,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4353,7 +4342,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4370,7 +4358,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4387,7 +4374,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4401,7 +4387,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4440,10 +4425,9 @@
       }
     },
     "node_modules/convex/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6807,7 +6791,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -6912,7 +6895,6 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/presence",
-  "version": "0.3.3-alpha.0",
+  "version": "0.4.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/presence",
-      "version": "0.3.3-alpha.0",
+      "version": "0.4.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@convex-dev/batch-worker": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -74,8 +74,11 @@
       "default": "./dist/component/convex.config.js"
     }
   },
+  "dependencies": {
+    "@convex-dev/batch-worker": "^0.2.0"
+  },
   "peerDependencies": {
-    "convex": "^1.24.8",
+    "convex": "^1.36.1",
     "expo-crypto": ">=14.1.0",
     "react": "~18.3.1 || ^19.0.0",
     "react-dom": "~18.3.1 || ^19.0.0",
@@ -102,8 +105,8 @@
     "@typescript-eslint/parser": "^8.46.2",
     "@vitejs/plugin-react": "^5.1.0",
     "chokidar-cli": "3.0.0",
-    "convex": "1.35.1",
-    "convex-test": "^0.0.38",
+    "convex": "1.41.0",
+    "convex-test": "^0.0.51",
     "eslint": "^9.38.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/presence/issues"
   },
-  "version": "0.3.2",
+  "version": "0.3.3-alpha.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "support@convex.dev",
     "url": "https://github.com/get-convex/presence/issues"
   },
-  "version": "0.3.3-alpha.0",
+  "version": "0.4.0-alpha.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/client/_generated/_ignore.ts
+++ b/src/client/_generated/_ignore.ts
@@ -1,0 +1,4 @@
+// Placeholder so convex-test can locate the modules root for the test-only
+// app functions defined in ../index.test.ts (its import.meta.glob must
+// include a _generated directory).
+export {};

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -153,6 +153,47 @@ describe("presence client", () => {
     expect(users.every((u) => !u.online)).toBe(true);
   });
 
+  test("an earlier deadline interrupts the wait after a completed batch", async () => {
+    const t = initConvexTest();
+    // At t=1s, short expires while long remains alive until t=100s. Before
+    // this fix, the worker debounced directly to long's deadline and ignored
+    // pings for sessions created during that wait.
+    await t.mutation(testApi.heartbeat, {
+      roomId: "room1",
+      userId: "short",
+      sessionId: "short",
+      interval: 400,
+    });
+    await t.mutation(testApi.heartbeat, {
+      roomId: "room1",
+      userId: "long",
+      sessionId: "long",
+      interval: 40000,
+    });
+
+    vi.advanceTimersByTime(1000);
+    await t.finishInProgressScheduledFunctions();
+
+    await t.mutation(testApi.heartbeat, {
+      roomId: "room1",
+      userId: "new-short",
+      sessionId: "new-short",
+      interval: 400,
+    });
+    // Run the immediate post-batch query, then wake at new-short's deadline.
+    vi.advanceTimersByTime(0);
+    await t.finishInProgressScheduledFunctions();
+    vi.advanceTimersByTime(1000);
+    await t.finishInProgressScheduledFunctions();
+
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toMatchObject([
+      { userId: "long", online: true },
+      { userId: "new-short", online: false },
+      { userId: "short", online: false },
+    ]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
   test("list requires a valid room token", async () => {
     const t = initConvexTest();
     await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,0 +1,251 @@
+/// <reference types="vite/client" />
+import { v } from "convex/values";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  anyApi,
+  type ApiFromModules,
+  mutationGeneric,
+  queryGeneric,
+} from "convex/server";
+import { Presence } from "./index.js";
+import { components, initConvexTest } from "./setup.test.js";
+
+const presence = new Presence(components.presence);
+
+export const heartbeat = mutationGeneric({
+  args: {
+    roomId: v.string(),
+    userId: v.string(),
+    sessionId: v.string(),
+    interval: v.optional(v.number()),
+  },
+  handler: async (ctx, { roomId, userId, sessionId, interval = 1000 }) =>
+    presence.heartbeat(ctx, roomId, userId, sessionId, interval),
+});
+
+export const list = queryGeneric({
+  args: { roomToken: v.string() },
+  handler: async (ctx, { roomToken }) => presence.list(ctx, roomToken),
+});
+
+export const listRoom = queryGeneric({
+  args: { roomId: v.string(), onlineOnly: v.optional(v.boolean()) },
+  handler: async (ctx, { roomId, onlineOnly }) =>
+    presence.listRoom(ctx, roomId, onlineOnly),
+});
+
+export const listUser = queryGeneric({
+  args: { userId: v.string(), onlineOnly: v.optional(v.boolean()) },
+  handler: async (ctx, { userId, onlineOnly }) =>
+    presence.listUser(ctx, userId, onlineOnly),
+});
+
+export const disconnect = mutationGeneric({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, { sessionToken }) =>
+    presence.disconnect(ctx, sessionToken),
+});
+
+export const updateRoomUser = mutationGeneric({
+  args: { roomId: v.string(), userId: v.string(), data: v.any() },
+  handler: async (ctx, { roomId, userId, data }) =>
+    presence.updateRoomUser(ctx, roomId, userId, data),
+});
+
+export const removeRoomUser = mutationGeneric({
+  args: { roomId: v.string(), userId: v.string() },
+  handler: async (ctx, { roomId, userId }) =>
+    presence.removeRoomUser(ctx, roomId, userId),
+});
+
+export const removeRoom = mutationGeneric({
+  args: { roomId: v.string() },
+  handler: async (ctx, { roomId }) => presence.removeRoom(ctx, roomId),
+});
+
+const testApi = (
+  anyApi as unknown as ApiFromModules<{
+    "index.test": {
+      heartbeat: typeof heartbeat;
+      list: typeof list;
+      listRoom: typeof listRoom;
+      listUser: typeof listUser;
+      disconnect: typeof disconnect;
+      updateRoomUser: typeof updateRoomUser;
+      removeRoomUser: typeof removeRoomUser;
+      removeRoom: typeof removeRoom;
+    };
+  }>
+)["index.test"];
+
+const hb = (roomId: string, userId: string, sessionId: string) => ({
+  roomId,
+  userId,
+  sessionId,
+  interval: 1000,
+});
+
+describe("presence client", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("user stays online while any of their sessions is alive", async () => {
+    const t = initConvexTest();
+    // Two tabs for the same user.
+    await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    const { sessionToken } = await t.mutation(
+      testApi.heartbeat,
+      hb("room1", "user1", "tab2"),
+    );
+
+    // Keep tab2 alive well past tab1's timeout: tab1 gets disconnected by the
+    // worker but the user stays online through tab2.
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(2000);
+      await t.finishInProgressScheduledFunctions();
+      await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab2"));
+    }
+    let users = await t.query(testApi.listRoom, { roomId: "room1" });
+    expect(users).toMatchObject([{ userId: "user1", online: true }]);
+
+    // Disconnecting the last session takes the user offline.
+    await t.mutation(testApi.disconnect, { sessionToken });
+    users = await t.query(testApi.listRoom, { roomId: "room1" });
+    expect(users).toMatchObject([{ userId: "user1", online: false }]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("timed-out user comes back online on the next heartbeat", async () => {
+    const t = initConvexTest();
+    const first = await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toMatchObject([
+      { userId: "user1", online: false },
+    ]);
+
+    const second = await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toMatchObject([
+      { userId: "user1", online: true },
+    ]);
+    // Room tokens are stable; the timed-out session's token was invalidated.
+    expect(second.roomToken).toBe(first.roomToken);
+    expect(second.sessionToken).not.toBe(first.sessionToken);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("mass expiry drains across multiple worker batches", async () => {
+    const t = initConvexTest();
+    // More sessions than DISCONNECT_BATCH so the worker needs several rounds.
+    for (let i = 0; i < 70; i++) {
+      await t.mutation(testApi.heartbeat, hb("room1", `user${i}`, `session${i}`));
+    }
+    let users = await t.query(testApi.listRoom, { roomId: "room1" });
+    expect(users).toHaveLength(70);
+    expect(users.every((u) => u.online)).toBe(true);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    users = await t.query(testApi.listRoom, { roomId: "room1" });
+    expect(users).toHaveLength(70);
+    expect(users.every((u) => !u.online)).toBe(true);
+  });
+
+  test("list requires a valid room token", async () => {
+    const t = initConvexTest();
+    await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    expect(await t.query(testApi.list, { roomToken: "bogus" })).toEqual([]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("updateRoomUser data shows up in list", async () => {
+    const t = initConvexTest();
+    const { roomToken } = await t.mutation(
+      testApi.heartbeat,
+      hb("room1", "user1", "tab1"),
+    );
+    await t.mutation(testApi.updateRoomUser, {
+      roomId: "room1",
+      userId: "user1",
+      data: { typing: true },
+    });
+    expect(await t.query(testApi.list, { roomToken })).toMatchObject([
+      { userId: "user1", online: true, data: { typing: true } },
+    ]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("removeRoomUser removes the user entirely, not just offline", async () => {
+    const t = initConvexTest();
+    await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    await t.mutation(testApi.heartbeat, hb("room1", "user2", "tab2"));
+
+    await t.mutation(testApi.removeRoomUser, {
+      roomId: "room1",
+      userId: "user1",
+    });
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toMatchObject([
+      { userId: "user2", online: true },
+    ]);
+
+    // The worker wakes on user1's stale deadline and finds nothing to do.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toMatchObject([
+      { userId: "user2", online: false },
+    ]);
+  });
+
+  test("removeRoom removes all users and sessions", async () => {
+    const t = initConvexTest();
+    await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    await t.mutation(testApi.heartbeat, hb("room1", "user2", "tab2"));
+
+    await t.mutation(testApi.removeRoom, { roomId: "room1" });
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toEqual([]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await t.query(testApi.listRoom, { roomId: "room1" })).toEqual([]);
+  });
+
+  test("listUser lists a user's rooms with onlineOnly filtering", async () => {
+    const t = initConvexTest();
+    await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    const { sessionToken } = await t.mutation(
+      testApi.heartbeat,
+      hb("room2", "user1", "tab2"),
+    );
+    await t.mutation(testApi.disconnect, { sessionToken });
+
+    expect(await t.query(testApi.listUser, { userId: "user1" })).toMatchObject([
+      { roomId: "room1", online: true },
+      { roomId: "room2", online: false },
+    ]);
+    expect(
+      await t.query(testApi.listUser, { userId: "user1", onlineOnly: true }),
+    ).toMatchObject([{ roomId: "room1", online: true }]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("sessionId must be unique for a given room/user", async () => {
+    const t = initConvexTest();
+    await t.mutation(testApi.heartbeat, hb("room1", "user1", "tab1"));
+    await expect(
+      t.mutation(testApi.heartbeat, hb("room2", "user1", "tab1")),
+    ).rejects.toThrow(/unique/);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+
+  test("disconnect with an unknown token is a no-op", async () => {
+    const t = initConvexTest();
+    const { roomToken } = await t.mutation(
+      testApi.heartbeat,
+      hb("room1", "user1", "tab1"),
+    );
+    await t.mutation(testApi.disconnect, { sessionToken: "bogus" });
+    expect(await t.query(testApi.list, { roomToken })).toMatchObject([
+      { userId: "user1", online: true },
+    ]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+  });
+});

--- a/src/client/setup.test.ts
+++ b/src/client/setup.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="vite/client" />
+import { test } from "vitest";
+import { convexTest } from "convex-test";
+import {
+  componentsGeneric,
+  defineSchema,
+  type GenericSchema,
+  type SchemaDefinition,
+} from "convex/server";
+import { type ComponentApi } from "../component/_generated/component.js";
+import { register } from "../test.js";
+
+export const modules = import.meta.glob("./**/*.*s");
+
+export function initConvexTest<
+  Schema extends SchemaDefinition<GenericSchema, boolean>,
+>(schema?: Schema) {
+  const t = convexTest(schema ?? (defineSchema({}) as Schema), modules);
+  register(t);
+  return t;
+}
+
+export const components = componentsGeneric() as unknown as {
+  presence: ComponentApi;
+};
+
+test("setup", () => {});

--- a/src/component.test.ts
+++ b/src/component.test.ts
@@ -1,0 +1,83 @@
+/// <reference types="vite/client" />
+import batchWorker from "@convex-dev/batch-worker/test";
+import { anyApi, type ApiFromModules } from "convex/server";
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import * as publicFunctions from "./component/public.js";
+import schema from "./component/schema.js";
+
+const modules = import.meta.glob("./component/**/*.ts");
+const componentApi = (
+  anyApi as unknown as ApiFromModules<{ public: typeof publicFunctions }>
+).public;
+
+function initComponentTest() {
+  const t = convexTest(schema, modules);
+  batchWorker.register(t, "batchWorker");
+  return t;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("a legacy scheduled disconnect removes a deadline-less session", async () => {
+  const t = initComponentTest();
+  await t.run(async (ctx) => {
+    await ctx.db.insert("presence", {
+      roomId: "room1",
+      userId: "user1",
+      online: true,
+      lastDisconnected: 0,
+    });
+    await ctx.db.insert("sessions", {
+      roomId: "room1",
+      userId: "user1",
+      sessionId: "session1",
+    });
+    await ctx.db.insert("sessionTokens", {
+      sessionId: "session1",
+      token: "legacy-token",
+    });
+  });
+
+  await t.mutation(componentApi.disconnect, {
+    sessionToken: "legacy-token",
+    scheduled: true,
+  });
+
+  await t.run(async (ctx) => {
+    expect(await ctx.db.query("sessions").first()).toBeNull();
+    expect(await ctx.db.query("sessionTokens").first()).toBeNull();
+    expect(await ctx.db.query("presence").first()).toMatchObject({
+      online: false,
+    });
+  });
+});
+
+test("a legacy scheduled disconnect ignores a migrated session", async () => {
+  const t = initComponentTest();
+  const { sessionToken } = await t.mutation(componentApi.heartbeat, {
+    roomId: "room1",
+    userId: "user1",
+    sessionId: "session1",
+    interval: 1000,
+  });
+
+  await t.mutation(componentApi.disconnect, {
+    sessionToken,
+    scheduled: true,
+  });
+
+  await t.run(async (ctx) => {
+    expect(await ctx.db.query("sessions").first()).not.toBeNull();
+    expect(await ctx.db.query("sessionTokens").first()).not.toBeNull();
+    expect(await ctx.db.query("presence").first()).toMatchObject({
+      online: true,
+    });
+  });
+});

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -10,6 +10,7 @@
 
 import type * as public_ from "../public.js";
 
+import type { ComponentApi as BatchWorkerApi } from "@convex-dev/batch-worker/_generated/component.js";
 import type {
   ApiFromModules,
   FilterApi,
@@ -47,4 +48,6 @@ export const internal: FilterApi<
   FunctionReference<any, "internal">
 > = anyApi as any;
 
-export const components = componentsGeneric() as unknown as {};
+export const components = componentsGeneric() as unknown as {
+  batchWorker: BatchWorkerApi;
+};

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -10,7 +10,6 @@
 
 import type * as public_ from "../public.js";
 
-import type { ComponentApi as BatchWorkerApi } from "@convex-dev/batch-worker/_generated/component.js";
 import type {
   ApiFromModules,
   FilterApi,
@@ -49,5 +48,5 @@ export const internal: FilterApi<
 > = anyApi as any;
 
 export const components = componentsGeneric() as unknown as {
-  batchWorker: BatchWorkerApi;
+  batchWorker: import("@convex-dev/batch-worker/_generated/component.js").ComponentApi<"batchWorker">;
 };

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -27,7 +27,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       disconnect: FunctionReference<
         "mutation",
         "internal",
-        { sessionToken: string },
+        { scheduled?: boolean; sessionToken: string },
         null,
         Name
       >;

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -27,7 +27,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       disconnect: FunctionReference<
         "mutation",
         "internal",
-        { scheduled?: boolean; sessionToken: string },
+        { sessionToken: string },
         null,
         Name
       >;

--- a/src/component/convex.config.ts
+++ b/src/component/convex.config.ts
@@ -1,3 +1,9 @@
 import { defineComponent } from "convex/server";
+import batchWorker from "@convex-dev/batch-worker/convex.config.js";
 
-export default defineComponent("presence");
+const component = defineComponent("presence");
+// Runs the singleton disconnect worker (see public.ts) so session timeouts
+// don't need a scheduled function per session.
+component.use(batchWorker);
+
+export default component;

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -53,13 +53,11 @@ export const heartbeat = mutation({
       await ctx.db.patch("sessions", session._id, { deadline });
     }
 
-    // Wake the disconnect worker if this deadline may be earlier than the one
-    // it's sleeping until: a new session while the worker may be fully idle,
-    // or an existing session shrinking its deadline. Debouncing bounds a
-    // burst of joins to one worker wakeup per second.
+    // Wake disconnect worker if potentially needed. Legacy sessions without
+    // a deadline ping like new sessions, starting the worker post-upgrade.
     // TODO: update batch-worker to ignore pings that wouldn't move its wakeup
     // earlier, skipping the per-debounce-window wakeup entirely.
-    if (!session || deadline < session.deadline) {
+    if (!session || deadline < (session.deadline ?? Infinity)) {
       await ping(ctx, components.batchWorker, {
         name: "disconnect",
         workQuery: internal.public.getExpiredSessions,
@@ -84,7 +82,7 @@ export const heartbeat = mutation({
       });
     }
 
-    // Fetch/generate token to list room presence.
+    // Generate token to list room presence.
     let roomToken: string;
     const roomTokenRecord = await ctx.db
       .query("roomTokens")
@@ -97,7 +95,7 @@ export const heartbeat = mutation({
       await ctx.db.insert("roomTokens", { roomId, token: roomToken });
     }
 
-    // Fetch/generate token to disconnect session.
+    // Generate token to disconnect session.
     let sessionToken: string;
     const sessionTokenRecord = await ctx.db
       .query("sessionTokens")
@@ -114,13 +112,13 @@ export const heartbeat = mutation({
   },
 });
 
-// Work query for the disconnect worker: the next batch of expired sessions,
-// or idle with a hint for when the earliest deadline could expire.
+// Fetch expired sessions for disconnect BatchWorker.
 export const getExpiredSessions = internalQuery({
   args: vBatchQueryArgs,
   returns: vBatchResult(v.object({ sessionIds: v.array(v.id("sessions")) })),
   handler: async (ctx) => {
     const now = Date.now();
+    // Return work if it exists.
     const expired = await ctx.db
       .query("sessions")
       .withIndex("deadline", (q) => q.lte("deadline", now))
@@ -132,8 +130,9 @@ export const getExpiredSessions = internalQuery({
       };
     }
 
-    // Nothing expired: sleep until the earliest deadline could pass. With no
-    // sessions at all, go fully idle until a ping.
+    // Tell worker to sleep until next deadline. Legacy deadline-less
+    // sessions sort first in the index, so they always land in the expired
+    // range above and `earliest` here has a deadline.
     const earliest = await ctx.db
       .query("sessions")
       .withIndex("deadline")
@@ -141,25 +140,34 @@ export const getExpiredSessions = internalQuery({
       .first();
     return {
       kind: "idle" as const,
-      timeoutMs: earliest ? earliest.deadline - now : undefined,
+      timeoutMs:
+        earliest?.deadline !== undefined ? earliest.deadline - now : undefined,
     };
   },
 });
 
-// Worker mutation for the disconnect worker: disconnects a batch of expired
-// sessions. The batch comes from a snapshot query, so treat it as stale and
-// skip sessions that have since heartbeated or disconnected.
+// Process disconnections passed in from BatchWorker. The batch comes from a
+// snapshot query, so skip sessions that have since heartbeated or
+// disconnected. Returning nothing makes the loop rerun immediately to check
+// for more work.
 export const disconnectExpired = internalMutation({
   args: { sessionIds: v.array(v.id("sessions")) },
-  returns: v.null(),
   handler: async (ctx, { sessionIds }) => {
     for (const sessionId of sessionIds) {
       const session = await ctx.db.get("sessions", sessionId);
-      if (session && session.deadline <= Date.now()) {
+      if (!session) {
+        continue;
+      }
+      if (session.deadline === undefined) {
+        // Legacy pre-worker session: give it one default heartbeat period to
+        // check in rather than assuming it's gone.
+        await ctx.db.patch("sessions", session._id, {
+          deadline: Date.now() + 10000 * 2.5,
+        });
+      } else if (session.deadline <= Date.now()) {
         await disconnectSession(ctx, session);
       }
     }
-    return null; // Rerun immediately; the loop re-queries for more.
   },
 });
 
@@ -293,10 +301,15 @@ export const listUser = query({
 export const disconnect = mutation({
   args: {
     sessionToken: v.string(),
+    // Set by timeouts scheduled by the previous implementation. The worker
+    // owns timeouts now, so these are ignored.
+    scheduled: v.optional(v.boolean()),
   },
   returns: v.null(),
-  handler: async (ctx, { sessionToken }) => {
-    // Idempotent: the session may already have timed out or disconnected.
+  handler: async (ctx, { sessionToken, scheduled }) => {
+    if (scheduled) {
+      return null;
+    }
     const sessionTokenRecord = await ctx.db
       .query("sessionTokens")
       .withIndex("token", (q) => q.eq("token", sessionToken))
@@ -352,9 +365,6 @@ export const removeRoomUser = mutation({
     }
     await ctx.db.delete("presence", userPresence._id);
 
-    // Remove the user from all sessions. No timeout bookkeeping needed: if
-    // one of these held the earliest deadline, the worker wakes at the stale
-    // time, finds nothing expired, and re-schedules.
     const sessions = await ctx.db
       .query("sessions")
       .withIndex("room_user_session", (q) =>
@@ -418,7 +428,6 @@ async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
   );
 }
 
-// Delete a session and its disconnect token.
 async function deleteSessionAndToken(
   ctx: MutationCtx,
   session: Doc<"sessions">,

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -55,15 +55,16 @@ export const heartbeat = mutation({
 
     // Wake the disconnect worker if this deadline may be earlier than the one
     // it's sleeping until: a new session while the worker may be fully idle,
-    // or an existing session shrinking its deadline.
-    // TODO: a burst of new sessions interrupts the sleeping worker once per
-    // ping; update batch-worker to ignore pings that wouldn't move its wakeup
-    // earlier.
+    // or an existing session shrinking its deadline. Debouncing bounds a
+    // burst of joins to one worker wakeup per second.
+    // TODO: update batch-worker to ignore pings that wouldn't move its wakeup
+    // earlier, skipping the per-debounce-window wakeup entirely.
     if (!session || deadline < session.deadline) {
       await ping(ctx, components.batchWorker, {
         name: "disconnect",
         workQuery: internal.public.getExpiredSessions,
         workerMutation: internal.public.disconnectExpired,
+        config: { debounceMs: 1000 },
       });
     }
 

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -3,10 +3,60 @@
 // See ../react/index.ts for the usePresence hook that maintains presence in a
 // client-side React component and ../client/index.ts for the Presence class that
 // can be used in Convex server functions.
+//
+// Session timeouts are enforced by a single deployment-wide worker rather than
+// per-session scheduled functions. Each heartbeat just bumps a deadline on its
+// session row; a singleton @convex-dev/batch-worker loop sleeps until the
+// earliest deadline in the deployment and disconnects sessions that pass it
+// (see expiredSessions and disconnectExpired below).
 
 import { v } from "convex/values";
-import { mutation, query, type QueryCtx } from "./_generated/server.js";
-import { api } from "./_generated/api.js";
+import {
+  ping,
+  vBatchQueryArgs,
+  vBatchResult,
+  vWorkerResult,
+} from "@convex-dev/batch-worker";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server.js";
+import { components, internal } from "./_generated/api.js";
+import type { Doc } from "./_generated/dataModel.js";
+
+// Name of the singleton batch-worker loop that disconnects timed-out sessions.
+const DISCONNECT_WORKER = "disconnect";
+
+// Max sessions to disconnect per worker transaction, bounding transaction
+// size during mass expiry (e.g., a large room dropping offline at once).
+const DISCONNECT_BATCH = 64;
+
+// Longest the worker loop sleeps between checks while any session exists.
+// Kept at or below the loop's pollIntervalMs so the loop sleeps in its
+// "running" state, where heartbeat pings are read-only no-ops: a burst of
+// room joins neither interrupts nor OCC-conflicts with the sleeping loop.
+// The cost is one cheap wakeup per 30s while the deployment has sessions,
+// and up to 30s of extra disconnect latency for a session whose deadline
+// lands earlier than all existing ones (only possible when a client shrinks
+// its heartbeat interval). With the default 10s interval, deadlines are at
+// most 25s out, so wakeups land exactly on the earliest deadline.
+const MAX_WORKER_SLEEP_MS = 30_000;
+
+// Wake the disconnect worker's loop. Called whenever a write could move the
+// deployment's earliest deadline *earlier* (a new session, or an interval
+// shrink): only then can the loop's scheduled wakeup be too late. Cheap and
+// idempotent: a read-only no-op while the loop is already running.
+async function pingDisconnectWorker(ctx: MutationCtx) {
+  await ping(ctx, components.batchWorker, {
+    name: DISCONNECT_WORKER,
+    workQuery: internal.public.expiredSessions,
+    workerMutation: internal.public.disconnectExpired,
+  });
+}
 
 export const heartbeat = mutation({
   args: {
@@ -20,17 +70,33 @@ export const heartbeat = mutation({
     sessionToken: v.string(),
   }),
   handler: async (ctx, { roomId, userId, sessionId, interval = 10000 }) => {
-    // Update or create session
+    // A session times out if no heartbeat arrives within 2.5x the heartbeat
+    // period. Bumping this deadline is the entire keepalive mechanism: the
+    // disconnect worker watches the earliest deadline in the deployment.
+    const deadline = Date.now() + interval * 2.5;
+
+    // Update or create session. Deadlines normally only move later, so an
+    // ordinary heartbeat doesn't need to wake the worker — its scheduled
+    // wakeup is already early enough. Only a brand-new session (the loop may
+    // be fully idle) or a deadline moving earlier (interval shrink) does.
+    let needsPing = false;
     const session = await ctx.db
       .query("sessions")
       .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
       .unique();
     if (!session) {
-      await ctx.db.insert("sessions", { roomId, userId, sessionId });
+      await ctx.db.insert("sessions", { roomId, userId, sessionId, deadline });
+      needsPing = true;
     } else if (session.roomId !== roomId || session.userId !== userId) {
       throw new Error(
         `sessionId ${sessionId} must be unique for a given room/user`,
       );
+    } else {
+      needsPing = deadline < session.deadline;
+      await ctx.db.patch("sessions", session._id, { deadline });
+    }
+    if (needsPing) {
+      await pingDisconnectWorker(ctx);
     }
 
     // Set user online if needed.
@@ -47,15 +113,6 @@ export const heartbeat = mutation({
         online: true,
         lastDisconnected: 0,
       });
-    }
-
-    // Cancel any existing timeout for session.
-    const existingTimeout = await ctx.db
-      .query("sessionTimeouts")
-      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
-      .unique();
-    if (existingTimeout) {
-      await ctx.scheduler.cancel(existingTimeout.scheduledFunctionId);
     }
 
     // Generate token to list room presence.
@@ -84,27 +141,68 @@ export const heartbeat = mutation({
       await ctx.db.insert("sessionTokens", { sessionId, token: sessionToken });
     }
 
-    // Schedule timeout heartbeat for 2.5x heartbeat period.
-    const timeout = await ctx.scheduler.runAfter(
-      interval * 2.5,
-      api.public.disconnect,
-      {
-        sessionToken: sessionToken,
-        scheduled: true,
-      },
-    );
-    if (existingTimeout) {
-      await ctx.db.patch("sessionTimeouts", existingTimeout._id, {
-        scheduledFunctionId: timeout,
-      });
-    } else {
-      await ctx.db.insert("sessionTimeouts", {
-        sessionId,
-        scheduledFunctionId: timeout,
-      });
+    return { roomToken, sessionToken };
+  },
+});
+
+// Work query for the disconnect worker: returns the next batch of expired
+// sessions, or idle with a hint for when the earliest deadline could expire.
+export const expiredSessions = internalQuery({
+  args: vBatchQueryArgs,
+  returns: vBatchResult(v.object({ sessionIds: v.array(v.id("sessions")) })),
+  handler: async (ctx) => {
+    const now = Date.now();
+    const expired = await ctx.db
+      .query("sessions")
+      .withIndex("deadline", (q) => q.lte("deadline", now))
+      .take(DISCONNECT_BATCH);
+    if (expired.length > 0) {
+      return {
+        kind: "work" as const,
+        batch: { sessionIds: expired.map((session) => session._id) },
+      };
     }
 
-    return { roomToken, sessionToken: sessionToken };
+    // Nothing expired: sleep until the earliest deadline could pass (capped
+    // at MAX_WORKER_SLEEP_MS to stay in the ping-absorbing running state).
+    // With no sessions at all, go fully idle — the next session-creating
+    // heartbeat pings the loop awake. Since extend-only heartbeats don't
+    // ping, the loop wakes at most once per heartbeat interval (sleeping on
+    // a deadline that has since been extended) plus once per actual
+    // disconnect, no matter how many sessions exist.
+    const earliest = await ctx.db
+      .query("sessions")
+      .withIndex("deadline")
+      .order("asc")
+      .first();
+    return {
+      kind: "idle" as const,
+      // Skip the post-work cooldown polling: go straight back to sleep.
+      cooldownMs: 0,
+      pollIntervalMs: MAX_WORKER_SLEEP_MS,
+      timeoutMs: earliest
+        ? Math.min(earliest.deadline - now, MAX_WORKER_SLEEP_MS)
+        : undefined,
+    };
+  },
+});
+
+// Worker mutation for the disconnect worker: disconnects a batch of sessions
+// found by expiredSessions. The batch comes from a snapshot read and may be
+// stale, so re-validate every session against current state — it may have
+// heartbeated (deadline extended) or disconnected since.
+export const disconnectExpired = internalMutation({
+  args: { sessionIds: v.array(v.id("sessions")) },
+  returns: vWorkerResult,
+  handler: async (ctx, { sessionIds }) => {
+    for (const sessionId of sessionIds) {
+      const session = await ctx.db.get("sessions", sessionId);
+      if (!session || session.deadline > Date.now()) {
+        continue; // already disconnected, or a heartbeat raced the snapshot
+      }
+      await disconnectSession(ctx, session);
+    }
+    return null; // rerun immediately; the loop re-queries for more
   },
 });
 
@@ -238,24 +336,22 @@ export const listUser = query({
 export const disconnect = mutation({
   args: {
     sessionToken: v.string(),
-    scheduled: v.optional(v.boolean()),
   },
   returns: v.null(),
-  handler: async (ctx, { sessionToken, scheduled }) => {
+  handler: async (ctx, { sessionToken }) => {
     const sessionTokenRecord = await ctx.db
       .query("sessionTokens")
       .withIndex("token", (q) => q.eq("token", sessionToken))
       .unique();
     if (!sessionTokenRecord) {
-      return;
+      // Session already timed out or disconnected; disconnect is idempotent.
+      return null;
     }
-    await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
-    const { sessionId } = sessionTokenRecord;
-
-    // Remove the session
     const session = await ctx.db
       .query("sessions")
-      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+      .withIndex("sessionId", (q) =>
+        q.eq("sessionId", sessionTokenRecord.sessionId),
+      )
       .unique();
     if (!session) {
       console.error(
@@ -263,47 +359,11 @@ export const disconnect = mutation({
         sessionToken,
         "without a session",
       );
-      return;
+      await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
+      return null;
     }
-
-    const { roomId, userId } = session;
-    await ctx.db.delete("sessions", session._id);
-
-    const userPresence = await getUserPresence(ctx, userId, roomId);
-    if (!userPresence) {
-      console.error(
-        "Should not have a session token",
-        sessionToken,
-        "without a user presence",
-      );
-      return;
-    }
-
-    // Mark user offline if they don't have any remaining sessions.
-    const remainingSessions = await ctx.db
-      .query("sessions")
-      .withIndex("room_user_session", (q) =>
-        q.eq("roomId", roomId).eq("userId", userId),
-      )
-      .collect();
-    if (userPresence.online && remainingSessions.length === 0) {
-      await ctx.db.patch("presence", userPresence._id, {
-        online: false,
-        lastDisconnected: Date.now(),
-      });
-    }
-
-    // Cancel timeout for this session.
-    const timeout = await ctx.db
-      .query("sessionTimeouts")
-      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
-      .unique();
-    if (timeout) {
-      if (!scheduled) {
-        await ctx.scheduler.cancel(timeout.scheduledFunctionId);
-      }
-      await ctx.db.delete("sessionTimeouts", timeout._id);
-    }
+    await disconnectSession(ctx, session);
+    return null;
   },
 });
 
@@ -339,7 +399,9 @@ export const removeRoomUser = mutation({
     }
     await ctx.db.delete("presence", userPresence._id);
 
-    // Remove the user from all sessions.
+    // Remove the user from all sessions. No timeout bookkeeping needed: if
+    // one of these held the earliest deadline, the worker wakes at the stale
+    // time, finds nothing expired, and re-schedules.
     const sessions = await ctx.db
       .query("sessions")
       .withIndex("room_user_session", (q) =>
@@ -354,14 +416,6 @@ export const removeRoomUser = mutation({
         .unique();
       if (sessionToken) {
         await ctx.db.delete("sessionTokens", sessionToken._id);
-      }
-      const timeout = await ctx.db
-        .query("sessionTimeouts")
-        .withIndex("sessionId", (q) => q.eq("sessionId", session.sessionId))
-        .unique();
-      if (timeout) {
-        await ctx.scheduler.cancel(timeout.scheduledFunctionId);
-        await ctx.db.delete("sessionTimeouts", timeout._id);
       }
     }
     return null;
@@ -397,15 +451,6 @@ export const removeRoom = mutation({
       if (sessionToken) {
         await ctx.db.delete("sessionTokens", sessionToken._id);
       }
-
-      const timeout = await ctx.db
-        .query("sessionTimeouts")
-        .withIndex("sessionId", (q) => q.eq("sessionId", session.sessionId))
-        .unique();
-      if (timeout) {
-        await ctx.scheduler.cancel(timeout.scheduledFunctionId);
-        await ctx.db.delete("sessionTimeouts", timeout._id);
-      }
     }
 
     const roomToken = await ctx.db
@@ -433,6 +478,42 @@ async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
       )
       .unique())
   );
+}
+
+// Disconnect a session, marking its user offline if it was their last session
+// in the room. Shared by graceful disconnects and worker timeouts.
+async function disconnectSession(ctx: MutationCtx, session: Doc<"sessions">) {
+  const { roomId, userId, sessionId } = session;
+  await ctx.db.delete("sessions", session._id);
+
+  const sessionToken = await ctx.db
+    .query("sessionTokens")
+    .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+    .unique();
+  if (sessionToken) {
+    await ctx.db.delete("sessionTokens", sessionToken._id);
+  }
+
+  // Mark user offline if they don't have any remaining sessions.
+  const remainingSession = await ctx.db
+    .query("sessions")
+    .withIndex("room_user_session", (q) =>
+      q.eq("roomId", roomId).eq("userId", userId),
+    )
+    .first();
+  if (!remainingSession) {
+    const userPresence = await getUserPresence(ctx, userId, roomId);
+    if (!userPresence) {
+      console.error("Session", sessionId, "had no presence record");
+      return;
+    }
+    if (userPresence.online) {
+      await ctx.db.patch("presence", userPresence._id, {
+        online: false,
+        lastDisconnected: Date.now(),
+      });
+    }
+  }
 }
 
 // TODO: rotate the room tokens

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -118,9 +118,6 @@ export const getExpiredSessions = internalQuery({
   returns: vBatchResult(
     v.object({
       sessionIds: v.array(v.id("sessions")),
-      // The deadline after this batch, if it drains all expired sessions.
-      // The worker sleeps until then, ignoring pings.
-      nextDeadline: v.optional(v.number()),
     }),
   ),
   handler: async (ctx) => {
@@ -131,21 +128,10 @@ export const getExpiredSessions = internalQuery({
       .withIndex("deadline", (q) => q.lte("deadline", now))
       .take(DISCONNECT_BATCH);
     if (expired.length > 0) {
-      // If this batch drains everything currently expired, no deadline can
-      // beat the next upcoming one, so tell the worker when to check next.
-      let nextDeadline: number | undefined;
-      if (expired.length < DISCONNECT_BATCH) {
-        const upcoming = await ctx.db
-          .query("sessions")
-          .withIndex("deadline", (q) => q.gt("deadline", now))
-          .first();
-        nextDeadline = upcoming?.deadline;
-      }
       return {
         kind: "work" as const,
         batch: {
           sessionIds: expired.map((session) => session._id),
-          nextDeadline,
         },
       };
     }
@@ -160,6 +146,9 @@ export const getExpiredSessions = internalQuery({
       .first();
     return {
       kind: "idle" as const,
+      // Skip BatchWorker's default cooldown: session deadlines already tell
+      // us exactly when to wake, and pings can interrupt this idle wait.
+      cooldownMs: 0,
       timeoutMs:
         earliest?.deadline !== undefined ? earliest.deadline - now : undefined,
     };
@@ -167,16 +156,14 @@ export const getExpiredSessions = internalQuery({
 });
 
 // Process disconnections passed in from BatchWorker. The batch comes from a
-// snapshot query, so skip sessions that have since heartbeated or
-// disconnected. Returning a debounce makes the worker sleep until the next
-// deadline, ignoring pings; returning nothing makes it rerun immediately.
+// snapshot query, so skip sessions that have since heartbeated or disconnected.
+// Rerun immediately afterward so BatchWorker can establish an OCC dependency
+// before entering its interruptible idle wait.
 export const disconnectExpired = internalMutation({
   args: {
     sessionIds: v.array(v.id("sessions")),
-    nextDeadline: v.optional(v.number()),
   },
-  handler: async (ctx, { sessionIds, nextDeadline }) => {
-    let adoptedLegacy = false;
+  handler: async (ctx, { sessionIds }) => {
     for (const sessionId of sessionIds) {
       const session = await ctx.db.get("sessions", sessionId);
       if (!session) {
@@ -188,15 +175,9 @@ export const disconnectExpired = internalMutation({
         await ctx.db.patch("sessions", session._id, {
           deadline: Date.now() + 10000 * 2.5,
         });
-        adoptedLegacy = true;
       } else if (session.deadline <= Date.now()) {
         await disconnectSession(ctx, session);
       }
-    }
-    // Adopted legacy deadlines may fall before nextDeadline; rerun instead of
-    // oversleeping so the query recomputes with them included.
-    if (nextDeadline !== undefined && !adoptedLegacy) {
-      return { debounceMs: Math.max(0, nextDeadline - Date.now()) };
     }
   },
 });
@@ -337,9 +318,6 @@ export const disconnect = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { sessionToken, scheduled }) => {
-    if (scheduled) {
-      return null;
-    }
     const sessionTokenRecord = await ctx.db
       .query("sessionTokens")
       .withIndex("token", (q) => q.eq("token", sessionToken))
@@ -353,6 +331,12 @@ export const disconnect = mutation({
         q.eq("sessionId", sessionTokenRecord.sessionId),
       )
       .unique();
+    // Preserve legacy scheduled disconnects for sessions that haven't
+    // heartbeated since upgrading. Once a heartbeat assigns a deadline, the
+    // worker owns the timeout and the old scheduled call is stale.
+    if (scheduled && session?.deadline !== undefined) {
+      return null;
+    }
     if (session) {
       await disconnectSession(ctx, session);
     } else {

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -115,7 +115,14 @@ export const heartbeat = mutation({
 // Fetch expired sessions for disconnect BatchWorker.
 export const getExpiredSessions = internalQuery({
   args: vBatchQueryArgs,
-  returns: vBatchResult(v.object({ sessionIds: v.array(v.id("sessions")) })),
+  returns: vBatchResult(
+    v.object({
+      sessionIds: v.array(v.id("sessions")),
+      // The deadline after this batch, if it drains all expired sessions.
+      // The worker sleeps until then, ignoring pings.
+      nextDeadline: v.optional(v.number()),
+    }),
+  ),
   handler: async (ctx) => {
     const now = Date.now();
     // Return work if it exists.
@@ -124,9 +131,22 @@ export const getExpiredSessions = internalQuery({
       .withIndex("deadline", (q) => q.lte("deadline", now))
       .take(DISCONNECT_BATCH);
     if (expired.length > 0) {
+      // If this batch drains everything currently expired, no deadline can
+      // beat the next upcoming one, so tell the worker when to check next.
+      let nextDeadline: number | undefined;
+      if (expired.length < DISCONNECT_BATCH) {
+        const upcoming = await ctx.db
+          .query("sessions")
+          .withIndex("deadline", (q) => q.gt("deadline", now))
+          .first();
+        nextDeadline = upcoming?.deadline;
+      }
       return {
         kind: "work" as const,
-        batch: { sessionIds: expired.map((session) => session._id) },
+        batch: {
+          sessionIds: expired.map((session) => session._id),
+          nextDeadline,
+        },
       };
     }
 
@@ -148,11 +168,15 @@ export const getExpiredSessions = internalQuery({
 
 // Process disconnections passed in from BatchWorker. The batch comes from a
 // snapshot query, so skip sessions that have since heartbeated or
-// disconnected. Returning nothing makes the loop rerun immediately to check
-// for more work.
+// disconnected. Returning a debounce makes the worker sleep until the next
+// deadline, ignoring pings; returning nothing makes it rerun immediately.
 export const disconnectExpired = internalMutation({
-  args: { sessionIds: v.array(v.id("sessions")) },
-  handler: async (ctx, { sessionIds }) => {
+  args: {
+    sessionIds: v.array(v.id("sessions")),
+    nextDeadline: v.optional(v.number()),
+  },
+  handler: async (ctx, { sessionIds, nextDeadline }) => {
+    let adoptedLegacy = false;
     for (const sessionId of sessionIds) {
       const session = await ctx.db.get("sessions", sessionId);
       if (!session) {
@@ -164,9 +188,15 @@ export const disconnectExpired = internalMutation({
         await ctx.db.patch("sessions", session._id, {
           deadline: Date.now() + 10000 * 2.5,
         });
+        adoptedLegacy = true;
       } else if (session.deadline <= Date.now()) {
         await disconnectSession(ctx, session);
       }
+    }
+    // Adopted legacy deadlines may fall before nextDeadline; rerun instead of
+    // oversleeping so the query recomputes with them included.
+    if (nextDeadline !== undefined && !adoptedLegacy) {
+      return { debounceMs: Math.max(0, nextDeadline - Date.now()) };
     }
   },
 });

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -11,12 +11,7 @@
 // (see expiredSessions and disconnectExpired below).
 
 import { v } from "convex/values";
-import {
-  ping,
-  vBatchQueryArgs,
-  vBatchResult,
-  vWorkerResult,
-} from "@convex-dev/batch-worker";
+import { ping, vBatchQueryArgs, vBatchResult } from "@convex-dev/batch-worker";
 import {
   internalMutation,
   internalQuery,
@@ -27,9 +22,6 @@ import {
 } from "./_generated/server.js";
 import { components, internal } from "./_generated/api.js";
 import type { Doc } from "./_generated/dataModel.js";
-
-// Name of the singleton batch-worker loop that disconnects timed-out sessions.
-const DISCONNECT_WORKER = "disconnect";
 
 // Max sessions to disconnect per worker transaction, bounding transaction
 // size during mass expiry (e.g., a large room dropping offline at once).
@@ -45,18 +37,6 @@ const DISCONNECT_BATCH = 64;
 // its heartbeat interval). With the default 10s interval, deadlines are at
 // most 25s out, so wakeups land exactly on the earliest deadline.
 const MAX_WORKER_SLEEP_MS = 30_000;
-
-// Wake the disconnect worker's loop. Called whenever a write could move the
-// deployment's earliest deadline *earlier* (a new session, or an interval
-// shrink): only then can the loop's scheduled wakeup be too late. Cheap and
-// idempotent: a read-only no-op while the loop is already running.
-async function pingDisconnectWorker(ctx: MutationCtx) {
-  await ping(ctx, components.batchWorker, {
-    name: DISCONNECT_WORKER,
-    workQuery: internal.public.expiredSessions,
-    workerMutation: internal.public.disconnectExpired,
-  });
-}
 
 export const heartbeat = mutation({
   args: {
@@ -75,28 +55,37 @@ export const heartbeat = mutation({
     // disconnect worker watches the earliest deadline in the deployment.
     const deadline = Date.now() + interval * 2.5;
 
-    // Update or create session. Deadlines normally only move later, so an
-    // ordinary heartbeat doesn't need to wake the worker — its scheduled
-    // wakeup is already early enough. Only a brand-new session (the loop may
-    // be fully idle) or a deadline moving earlier (interval shrink) does.
-    let needsPing = false;
+    // Update or create session, minting the token used to disconnect it.
+    let sessionToken: string;
     const session = await ctx.db
       .query("sessions")
       .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
       .unique();
     if (!session) {
-      await ctx.db.insert("sessions", { roomId, userId, sessionId, deadline });
-      needsPing = true;
+      sessionToken = crypto.randomUUID();
+      await ctx.db.insert("sessions", {
+        roomId,
+        userId,
+        sessionId,
+        deadline,
+        token: sessionToken,
+      });
+      // Wake the disconnect worker in case it's fully idle (it only goes
+      // idle when no sessions exist; while it's running this is a read-only
+      // no-op). Heartbeats for existing sessions never need this: they only
+      // push deadlines later, so the worker's next wakeup stays early enough.
+      await ping(ctx, components.batchWorker, {
+        name: "disconnect",
+        workQuery: internal.public.expiredSessions,
+        workerMutation: internal.public.disconnectExpired,
+      });
     } else if (session.roomId !== roomId || session.userId !== userId) {
       throw new Error(
         `sessionId ${sessionId} must be unique for a given room/user`,
       );
     } else {
-      needsPing = deadline < session.deadline;
+      sessionToken = session.token;
       await ctx.db.patch("sessions", session._id, { deadline });
-    }
-    if (needsPing) {
-      await pingDisconnectWorker(ctx);
     }
 
     // Set user online if needed.
@@ -128,39 +117,24 @@ export const heartbeat = mutation({
       await ctx.db.insert("roomTokens", { roomId, token: roomToken });
     }
 
-    // Generate token to disconnect session.
-    let sessionToken: string;
-    const sessionTokenRecord = await ctx.db
-      .query("sessionTokens")
-      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
-      .unique();
-    if (sessionTokenRecord) {
-      sessionToken = sessionTokenRecord.token;
-    } else {
-      sessionToken = crypto.randomUUID();
-      await ctx.db.insert("sessionTokens", { sessionId, token: sessionToken });
-    }
-
     return { roomToken, sessionToken };
   },
 });
 
-// Work query for the disconnect worker: returns the next batch of expired
-// sessions, or idle with a hint for when the earliest deadline could expire.
+// Work query for the disconnect worker: reports whether any session is past
+// its deadline and, if not, when the earliest one could expire. The worker
+// mutation finds the expired sessions itself, so the batch carries no data.
 export const expiredSessions = internalQuery({
   args: vBatchQueryArgs,
-  returns: vBatchResult(v.object({ sessionIds: v.array(v.id("sessions")) })),
+  returns: vBatchResult(v.object({})),
   handler: async (ctx) => {
     const now = Date.now();
     const expired = await ctx.db
       .query("sessions")
       .withIndex("deadline", (q) => q.lte("deadline", now))
-      .take(DISCONNECT_BATCH);
-    if (expired.length > 0) {
-      return {
-        kind: "work" as const,
-        batch: { sessionIds: expired.map((session) => session._id) },
-      };
+      .first();
+    if (expired) {
+      return { kind: "work" as const, batch: {} };
     }
 
     // Nothing expired: sleep until the earliest deadline could pass (capped
@@ -187,19 +161,18 @@ export const expiredSessions = internalQuery({
   },
 });
 
-// Worker mutation for the disconnect worker: disconnects a batch of sessions
-// found by expiredSessions. The batch comes from a snapshot read and may be
-// stale, so re-validate every session against current state — it may have
-// heartbeated (deadline extended) or disconnected since.
+// Worker mutation for the disconnect worker: disconnects a batch of expired
+// sessions. It reads them itself rather than taking them from the work query,
+// so it only ever acts on state read in this transaction.
 export const disconnectExpired = internalMutation({
-  args: { sessionIds: v.array(v.id("sessions")) },
-  returns: vWorkerResult,
-  handler: async (ctx, { sessionIds }) => {
-    for (const sessionId of sessionIds) {
-      const session = await ctx.db.get("sessions", sessionId);
-      if (!session || session.deadline > Date.now()) {
-        continue; // already disconnected, or a heartbeat raced the snapshot
-      }
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const expired = await ctx.db
+      .query("sessions")
+      .withIndex("deadline", (q) => q.lte("deadline", Date.now()))
+      .take(DISCONNECT_BATCH);
+    for (const session of expired) {
       await disconnectSession(ctx, session);
     }
     return null; // rerun immediately; the loop re-queries for more
@@ -339,30 +312,14 @@ export const disconnect = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { sessionToken }) => {
-    const sessionTokenRecord = await ctx.db
-      .query("sessionTokens")
-      .withIndex("token", (q) => q.eq("token", sessionToken))
-      .unique();
-    if (!sessionTokenRecord) {
-      // Session already timed out or disconnected; disconnect is idempotent.
-      return null;
-    }
     const session = await ctx.db
       .query("sessions")
-      .withIndex("sessionId", (q) =>
-        q.eq("sessionId", sessionTokenRecord.sessionId),
-      )
+      .withIndex("token", (q) => q.eq("token", sessionToken))
       .unique();
-    if (!session) {
-      console.error(
-        "Should not have a session token",
-        sessionToken,
-        "without a session",
-      );
-      await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
-      return null;
+    // Idempotent: the session may already have timed out or disconnected.
+    if (session) {
+      await disconnectSession(ctx, session);
     }
-    await disconnectSession(ctx, session);
     return null;
   },
 });
@@ -410,13 +367,6 @@ export const removeRoomUser = mutation({
       .collect();
     for (const session of sessions) {
       await ctx.db.delete("sessions", session._id);
-      const sessionToken = await ctx.db
-        .query("sessionTokens")
-        .withIndex("sessionId", (q) => q.eq("sessionId", session.sessionId))
-        .unique();
-      if (sessionToken) {
-        await ctx.db.delete("sessionTokens", sessionToken._id);
-      }
     }
     return null;
   },
@@ -443,14 +393,6 @@ export const removeRoom = mutation({
       .collect();
     for (const session of sessions) {
       await ctx.db.delete("sessions", session._id);
-
-      const sessionToken = await ctx.db
-        .query("sessionTokens")
-        .withIndex("sessionId", (q) => q.eq("sessionId", session.sessionId))
-        .unique();
-      if (sessionToken) {
-        await ctx.db.delete("sessionTokens", sessionToken._id);
-      }
     }
 
     const roomToken = await ctx.db
@@ -485,14 +427,6 @@ async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
 async function disconnectSession(ctx: MutationCtx, session: Doc<"sessions">) {
   const { roomId, userId, sessionId } = session;
   await ctx.db.delete("sessions", session._id);
-
-  const sessionToken = await ctx.db
-    .query("sessionTokens")
-    .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
-    .unique();
-  if (sessionToken) {
-    await ctx.db.delete("sessionTokens", sessionToken._id);
-  }
 
   // Mark user offline if they don't have any remaining sessions.
   const remainingSession = await ctx.db

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -55,8 +55,6 @@ export const heartbeat = mutation({
 
     // Wake disconnect worker if potentially needed. Legacy sessions without
     // a deadline ping like new sessions, starting the worker post-upgrade.
-    // TODO: update batch-worker to ignore pings that wouldn't move its wakeup
-    // earlier, skipping the per-debounce-window wakeup entirely.
     if (!session || deadline < (session.deadline ?? Infinity)) {
       await ping(ctx, components.batchWorker, {
         name: "disconnect",

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -23,17 +23,6 @@ import type { Doc } from "./_generated/dataModel.js";
 // Max sessions to disconnect per worker transaction.
 const DISCONNECT_BATCH = 64;
 
-// Longest the worker loop sleeps between checks while any session exists.
-// Kept at or below the loop's pollIntervalMs so the loop sleeps in its
-// "running" state, where heartbeat pings are read-only no-ops: a burst of
-// room joins neither interrupts nor OCC-conflicts with the sleeping loop.
-// The cost is one cheap wakeup per 30s while the deployment has sessions,
-// and up to 30s of extra disconnect latency for a session whose deadline
-// lands earlier than all existing ones (only possible when a client shrinks
-// its heartbeat interval). With the default 10s interval, deadlines are at
-// most 25s out, so wakeups land exactly on the earliest deadline.
-const MAX_WORKER_SLEEP_MS = 30_000;
-
 export const heartbeat = mutation({
   args: {
     roomId: v.string(),
@@ -50,33 +39,32 @@ export const heartbeat = mutation({
     const deadline = Date.now() + interval * 2.5;
 
     // Create session or bump deadline.
-    let sessionToken: string;
     const session = await ctx.db
       .query("sessions")
       .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
       .unique();
     if (!session) {
-      sessionToken = crypto.randomUUID();
-      await ctx.db.insert("sessions", {
-        roomId,
-        userId,
-        sessionId,
-        deadline,
-        token: sessionToken,
-      });
-      // Wake disconnect worker if fully idle.
-      await ping(ctx, components.batchWorker, {
-        name: "disconnect",
-        workQuery: internal.public.getExpiredSessions,
-        workerMutation: internal.public.disconnectExpired,
-      });
+      await ctx.db.insert("sessions", { roomId, userId, sessionId, deadline });
     } else if (session.roomId !== roomId || session.userId !== userId) {
       throw new Error(
         `sessionId ${sessionId} must be unique for a given room/user`,
       );
     } else {
-      sessionToken = session.token;
       await ctx.db.patch("sessions", session._id, { deadline });
+    }
+
+    // Wake the disconnect worker if this deadline may be earlier than the one
+    // it's sleeping until: a new session while the worker may be fully idle,
+    // or an existing session shrinking its deadline.
+    // TODO: a burst of new sessions interrupts the sleeping worker once per
+    // ping; update batch-worker to ignore pings that wouldn't move its wakeup
+    // earlier.
+    if (!session || deadline < session.deadline) {
+      await ping(ctx, components.batchWorker, {
+        name: "disconnect",
+        workQuery: internal.public.getExpiredSessions,
+        workerMutation: internal.public.disconnectExpired,
+      });
     }
 
     // Set user online if needed.
@@ -108,33 +96,43 @@ export const heartbeat = mutation({
       await ctx.db.insert("roomTokens", { roomId, token: roomToken });
     }
 
+    // Fetch/generate token to disconnect session.
+    let sessionToken: string;
+    const sessionTokenRecord = await ctx.db
+      .query("sessionTokens")
+      .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
+      .unique();
+    if (sessionTokenRecord) {
+      sessionToken = sessionTokenRecord.token;
+    } else {
+      sessionToken = crypto.randomUUID();
+      await ctx.db.insert("sessionTokens", { sessionId, token: sessionToken });
+    }
+
     return { roomToken, sessionToken };
   },
 });
 
-// Work query for the disconnect worker: reports whether any session is past
-// its deadline and, if not, when the earliest one could expire. The worker
-// mutation finds the expired sessions itself, so the batch carries no data.
+// Work query for the disconnect worker: the next batch of expired sessions,
+// or idle with a hint for when the earliest deadline could expire.
 export const getExpiredSessions = internalQuery({
   args: vBatchQueryArgs,
-  returns: vBatchResult(v.object({})),
+  returns: vBatchResult(v.object({ sessionIds: v.array(v.id("sessions")) })),
   handler: async (ctx) => {
     const now = Date.now();
     const expired = await ctx.db
       .query("sessions")
       .withIndex("deadline", (q) => q.lte("deadline", now))
-      .first();
-    if (expired) {
-      return { kind: "work" as const, batch: {} };
+      .take(DISCONNECT_BATCH);
+    if (expired.length > 0) {
+      return {
+        kind: "work" as const,
+        batch: { sessionIds: expired.map((session) => session._id) },
+      };
     }
 
-    // Nothing expired: sleep until the earliest deadline could pass (capped
-    // at MAX_WORKER_SLEEP_MS to stay in the ping-absorbing running state).
-    // With no sessions at all, go fully idle — the next session-creating
-    // heartbeat pings the loop awake. Since extend-only heartbeats don't
-    // ping, the loop wakes at most once per heartbeat interval (sleeping on
-    // a deadline that has since been extended) plus once per actual
-    // disconnect, no matter how many sessions exist.
+    // Nothing expired: sleep until the earliest deadline could pass. With no
+    // sessions at all, go fully idle until a ping.
     const earliest = await ctx.db
       .query("sessions")
       .withIndex("deadline")
@@ -142,31 +140,25 @@ export const getExpiredSessions = internalQuery({
       .first();
     return {
       kind: "idle" as const,
-      // Skip the post-work cooldown polling: go straight back to sleep.
-      cooldownMs: 0,
-      pollIntervalMs: MAX_WORKER_SLEEP_MS,
-      timeoutMs: earliest
-        ? Math.min(earliest.deadline - now, MAX_WORKER_SLEEP_MS)
-        : undefined,
+      timeoutMs: earliest ? earliest.deadline - now : undefined,
     };
   },
 });
 
 // Worker mutation for the disconnect worker: disconnects a batch of expired
-// sessions. It reads them itself rather than taking them from the work query,
-// so it only ever acts on state read in this transaction.
+// sessions. The batch comes from a snapshot query, so treat it as stale and
+// skip sessions that have since heartbeated or disconnected.
 export const disconnectExpired = internalMutation({
-  args: {},
+  args: { sessionIds: v.array(v.id("sessions")) },
   returns: v.null(),
-  handler: async (ctx) => {
-    const expired = await ctx.db
-      .query("sessions")
-      .withIndex("deadline", (q) => q.lte("deadline", Date.now()))
-      .take(DISCONNECT_BATCH);
-    for (const session of expired) {
-      await disconnectSession(ctx, session);
+  handler: async (ctx, { sessionIds }) => {
+    for (const sessionId of sessionIds) {
+      const session = await ctx.db.get("sessions", sessionId);
+      if (session && session.deadline <= Date.now()) {
+        await disconnectSession(ctx, session);
+      }
     }
-    return null; // rerun immediately; the loop re-queries for more
+    return null; // Rerun immediately; the loop re-queries for more.
   },
 });
 
@@ -303,13 +295,25 @@ export const disconnect = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { sessionToken }) => {
-    const session = await ctx.db
-      .query("sessions")
+    // Idempotent: the session may already have timed out or disconnected.
+    const sessionTokenRecord = await ctx.db
+      .query("sessionTokens")
       .withIndex("token", (q) => q.eq("token", sessionToken))
       .unique();
-    // Idempotent: the session may already have timed out or disconnected.
+    if (!sessionTokenRecord) {
+      return null;
+    }
+    const session = await ctx.db
+      .query("sessions")
+      .withIndex("sessionId", (q) =>
+        q.eq("sessionId", sessionTokenRecord.sessionId),
+      )
+      .unique();
     if (session) {
       await disconnectSession(ctx, session);
+    } else {
+      console.error("Session token without a session", sessionToken);
+      await ctx.db.delete("sessionTokens", sessionTokenRecord._id);
     }
     return null;
   },
@@ -357,7 +361,7 @@ export const removeRoomUser = mutation({
       )
       .collect();
     for (const session of sessions) {
-      await ctx.db.delete("sessions", session._id);
+      await deleteSessionAndToken(ctx, session);
     }
     return null;
   },
@@ -383,7 +387,7 @@ export const removeRoom = mutation({
       .withIndex("room_user_session", (q) => q.eq("roomId", roomId))
       .collect();
     for (const session of sessions) {
-      await ctx.db.delete("sessions", session._id);
+      await deleteSessionAndToken(ctx, session);
     }
 
     const roomToken = await ctx.db
@@ -413,11 +417,26 @@ async function getUserPresence(ctx: QueryCtx, userId: string, roomId: string) {
   );
 }
 
+// Delete a session and its disconnect token.
+async function deleteSessionAndToken(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+) {
+  await ctx.db.delete("sessions", session._id);
+  const sessionToken = await ctx.db
+    .query("sessionTokens")
+    .withIndex("sessionId", (q) => q.eq("sessionId", session.sessionId))
+    .unique();
+  if (sessionToken) {
+    await ctx.db.delete("sessionTokens", sessionToken._id);
+  }
+}
+
 // Disconnect a session, marking its user offline if it was their last session
 // in the room. Shared by graceful disconnects and worker timeouts.
 async function disconnectSession(ctx: MutationCtx, session: Doc<"sessions">) {
   const { roomId, userId, sessionId } = session;
-  await ctx.db.delete("sessions", session._id);
+  await deleteSessionAndToken(ctx, session);
 
   // Mark user offline if they don't have any remaining sessions.
   const remainingSession = await ctx.db

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -4,11 +4,8 @@
 // client-side React component and ../client/index.ts for the Presence class that
 // can be used in Convex server functions.
 //
-// Session timeouts are enforced by a single deployment-wide worker rather than
-// per-session scheduled functions. Each heartbeat just bumps a deadline on its
-// session row; a singleton @convex-dev/batch-worker loop sleeps until the
-// earliest deadline in the deployment and disconnects sessions that pass it
-// (see expiredSessions and disconnectExpired below).
+// Heartbeats bump a disconnect deadline for a session and a background
+// batch-worker loop disconnects sessions that pass their deadline.
 
 import { v } from "convex/values";
 import { ping, vBatchQueryArgs, vBatchResult } from "@convex-dev/batch-worker";
@@ -23,8 +20,7 @@ import {
 import { components, internal } from "./_generated/api.js";
 import type { Doc } from "./_generated/dataModel.js";
 
-// Max sessions to disconnect per worker transaction, bounding transaction
-// size during mass expiry (e.g., a large room dropping offline at once).
+// Max sessions to disconnect per worker transaction.
 const DISCONNECT_BATCH = 64;
 
 // Longest the worker loop sleeps between checks while any session exists.
@@ -50,12 +46,10 @@ export const heartbeat = mutation({
     sessionToken: v.string(),
   }),
   handler: async (ctx, { roomId, userId, sessionId, interval = 10000 }) => {
-    // A session times out if no heartbeat arrives within 2.5x the heartbeat
-    // period. Bumping this deadline is the entire keepalive mechanism: the
-    // disconnect worker watches the earliest deadline in the deployment.
+    // Time out session if no heartbeat again within 2.5x interval.
     const deadline = Date.now() + interval * 2.5;
 
-    // Update or create session, minting the token used to disconnect it.
+    // Create session or bump deadline.
     let sessionToken: string;
     const session = await ctx.db
       .query("sessions")
@@ -70,13 +64,10 @@ export const heartbeat = mutation({
         deadline,
         token: sessionToken,
       });
-      // Wake the disconnect worker in case it's fully idle (it only goes
-      // idle when no sessions exist; while it's running this is a read-only
-      // no-op). Heartbeats for existing sessions never need this: they only
-      // push deadlines later, so the worker's next wakeup stays early enough.
+      // Wake disconnect worker if fully idle.
       await ping(ctx, components.batchWorker, {
         name: "disconnect",
-        workQuery: internal.public.expiredSessions,
+        workQuery: internal.public.getExpiredSessions,
         workerMutation: internal.public.disconnectExpired,
       });
     } else if (session.roomId !== roomId || session.userId !== userId) {
@@ -104,7 +95,7 @@ export const heartbeat = mutation({
       });
     }
 
-    // Generate token to list room presence.
+    // Fetch/generate token to list room presence.
     let roomToken: string;
     const roomTokenRecord = await ctx.db
       .query("roomTokens")
@@ -124,7 +115,7 @@ export const heartbeat = mutation({
 // Work query for the disconnect worker: reports whether any session is past
 // its deadline and, if not, when the earliest one could expire. The worker
 // mutation finds the expired sessions itself, so the batch carries no data.
-export const expiredSessions = internalQuery({
+export const getExpiredSessions = internalQuery({
   args: vBatchQueryArgs,
   returns: vBatchResult(v.object({})),
   handler: async (ctx) => {

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -21,13 +21,9 @@ export default defineSchema({
     // Time by which another heartbeat must arrive before the disconnect
     // worker disconnects the session. Bumped by every heartbeat.
     deadline: v.number(),
-    // Temporary token required to disconnect the session, minted by and
-    // returned from heartbeat.
-    token: v.string(),
   })
     .index("room_user_session", ["roomId", "userId", "sessionId"])
     .index("sessionId", ["sessionId"])
-    .index("token", ["token"])
     // Wait queue for the disconnect worker: earliest deadline first.
     .index("deadline", ["deadline"]),
 
@@ -39,4 +35,12 @@ export default defineSchema({
   })
     .index("token", ["token"])
     .index("room", ["roomId"]),
+
+  // Temporary tokens to disconnect individual sessions.
+  sessionTokens: defineTable({
+    token: v.string(),
+    sessionId: v.string(),
+  })
+    .index("token", ["token"])
+    .index("sessionId", ["sessionId"]),
 });

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -47,12 +47,7 @@ export default defineSchema({
     .index("token", ["token"])
     .index("sessionId", ["sessionId"]),
 
-  // Scheduled disconnects from the previous implementation, which the
-  // disconnect worker replaces. Unused: kept so existing deployments upgrade
-  // without a migration. Rows are inert and this table can be dropped once
-  // all pre-upgrade deployments are gone.
-  sessionTimeouts: defineTable({
-    sessionId: v.string(),
-    scheduledFunctionId: v.id("_scheduled_functions"),
-  }).index("sessionId", ["sessionId"]),
+  // The previous implementation's sessionTimeouts table is intentionally
+  // absent: existing deployments keep it (undeclared tables persist) and its
+  // rows are inert once the scheduled disconnects they track have fired.
 });

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -21,9 +21,13 @@ export default defineSchema({
     // Time by which another heartbeat must arrive before the disconnect
     // worker disconnects the session. Bumped by every heartbeat.
     deadline: v.number(),
+    // Temporary token required to disconnect the session, minted by and
+    // returned from heartbeat.
+    token: v.string(),
   })
     .index("room_user_session", ["roomId", "userId", "sessionId"])
     .index("sessionId", ["sessionId"])
+    .index("token", ["token"])
     // Wait queue for the disconnect worker: earliest deadline first.
     .index("deadline", ["deadline"]),
 
@@ -35,12 +39,4 @@ export default defineSchema({
   })
     .index("token", ["token"])
     .index("room", ["roomId"]),
-
-  // Temporary tokens to disconnect individual sessions.
-  sessionTokens: defineTable({
-    token: v.string(),
-    sessionId: v.string(),
-  })
-    .index("token", ["token"])
-    .index("sessionId", ["sessionId"]),
 });

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -18,9 +18,14 @@ export default defineSchema({
     roomId: v.string(),
     userId: v.string(),
     sessionId: v.string(),
+    // Time by which another heartbeat must arrive before the disconnect
+    // worker disconnects the session. Bumped by every heartbeat.
+    deadline: v.number(),
   })
     .index("room_user_session", ["roomId", "userId", "sessionId"])
-    .index("sessionId", ["sessionId"]),
+    .index("sessionId", ["sessionId"])
+    // Wait queue for the disconnect worker: earliest deadline first.
+    .index("deadline", ["deadline"]),
 
   // Temporary tokens to list presence in a room. These allow all members to
   // share the same cached query while offering some security.
@@ -38,10 +43,4 @@ export default defineSchema({
   })
     .index("token", ["token"])
     .index("sessionId", ["sessionId"]),
-
-  // Scheduled jobs to disconnect sessions after timeout.
-  sessionTimeouts: defineTable({
-    sessionId: v.string(),
-    scheduledFunctionId: v.id("_scheduled_functions"),
-  }).index("sessionId", ["sessionId"]),
 });

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -19,12 +19,15 @@ export default defineSchema({
     userId: v.string(),
     sessionId: v.string(),
     // Time by which another heartbeat must arrive before the disconnect
-    // worker disconnects the session. Bumped by every heartbeat.
-    deadline: v.number(),
+    // worker disconnects the session. Optional so existing deployments
+    // upgrade without a migration: sessions written by the previous
+    // implementation lack it and are assigned one by the worker.
+    deadline: v.optional(v.number()),
   })
     .index("room_user_session", ["roomId", "userId", "sessionId"])
     .index("sessionId", ["sessionId"])
-    // Wait queue for the disconnect worker: earliest deadline first.
+    // Wait queue for the disconnect worker: earliest deadline first, with
+    // legacy deadline-less sessions sorting to the front.
     .index("deadline", ["deadline"]),
 
   // Temporary tokens to list presence in a room. These allow all members to
@@ -43,4 +46,13 @@ export default defineSchema({
   })
     .index("token", ["token"])
     .index("sessionId", ["sessionId"]),
+
+  // Scheduled disconnects from the previous implementation, which the
+  // disconnect worker replaces. Unused: kept so existing deployments upgrade
+  // without a migration. Rows are inert and this table can be dropped once
+  // all pre-upgrade deployments are gone.
+  sessionTimeouts: defineTable({
+    sessionId: v.string(),
+    scheduledFunctionId: v.id("_scheduled_functions"),
+  }).index("sessionId", ["sessionId"]),
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import type { TestConvex } from "convex-test";
 import type { GenericSchema, SchemaDefinition } from "convex/server";
+import batchWorker from "@convex-dev/batch-worker/test";
 import schema from "./component/schema.js";
 const modules = import.meta.glob("./component/**/*.ts");
 
@@ -14,5 +15,8 @@ export function register(
   name: string = "presence",
 ) {
   t.registerComponent(name, schema, modules);
+  // Also register the nested batch-worker component that runs the disconnect
+  // worker. convex-test addresses nested components by slash-joined path.
+  batchWorker.register(t, `${name}/batchWorker`);
 }
 export default { register, schema, modules };


### PR DESCRIPTION
The previous implementation of Presence writes to the scheduler twice on every heartbeat which can get expensive. This implementation uses the BatchWorker component to operate a singleton that processes a batch of disconnects whenever there's work to do. This alone will make Presence much more efficient but also paves the way for us to change this to not use the scheduler at all, when we add lower level Convex OS primitives.

This change should be migration-safe since it only adds an optional field and should gracefully handle sessions from the previous version.