### PR TITLE
Fix presence cleanup races in React hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^17.0.0",
+        "happy-dom": "^20.10.6",
         "prettier": "^3.6.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -2187,6 +2188,23 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -2895,6 +2913,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -4001,6 +4032,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
@@ -4649,6 +4693,47 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7243,6 +7328,16 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "!src/**/*.test.*"
   ],
   "exports": {
     "./package.json": "./package.json",
@@ -111,6 +112,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^17.0.0",
+    "happy-dom": "^20.10.6",
     "prettier": "^3.6.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -39,9 +39,8 @@ export function usePresence(
   const convex = useConvex();
   const baseUrl = convexUrl ?? convex.url;
 
-  // Keep one stable ID for this hook instance. Including the room and user
-  // rotates the server session synchronously when either identity changes,
-  // without creating a throwaway session during the initial effect.
+  // Each hook instance has a stable ID. Including the room and user gives each
+  // presence identity a distinct server session.
   const [instanceId] = useState(() => Crypto.randomUUID());
   const sessionId = JSON.stringify([instanceId, roomId, userId]);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
@@ -98,8 +97,6 @@ export function usePresence(
     const sendHeartbeat = async () => {
       const result = await heartbeat({ roomId, userId, sessionId, interval });
       if (canceled) {
-        // Cleanup had no token for this in-flight heartbeat. Disconnect its
-        // session unless a newer effect now owns that same session.
         disconnectIfOrphaned(result.sessionToken);
         return;
       }

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -39,21 +39,22 @@ export function usePresence(
   const convex = useConvex();
   const baseUrl = convexUrl ?? convex.url;
 
-  const [sessionId, setSessionId] = useState(() => Crypto.randomUUID());
+  // Keep one stable ID for this hook instance. Including the room and user
+  // rotates the server session synchronously when either identity changes,
+  // without creating a throwaway session during the initial effect.
+  const [instanceId] = useState(() => Crypto.randomUUID());
+  const sessionId = JSON.stringify([instanceId, roomId, userId]);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
   const [roomToken, setRoomToken] = useState<string | null>(null);
 
   const sessionTokenRef = useRef<string | null>(null);
+  // A newer effect may adopt the same session when only `interval` changes.
+  const activeSessionIdRef = useRef<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const heartbeat = useSingleFlight(useMutation(presence.heartbeat));
-  const disconnect = useSingleFlight(useMutation(presence.disconnect));
-
-  const sendHeartbeat = useCallback(async () => {
-    const result = await heartbeat({ roomId, userId, sessionId, interval });
-    setRoomToken(result.roomToken);
-    setSessionToken(result.sessionToken);
-  }, [heartbeat, interval, roomId, sessionId, userId]);
+  // Every distinct token must be disconnected; useSingleFlight may drop calls.
+  const disconnect = useMutation(presence.disconnect);
 
   const fireAndForgetDisconnect = useCallback(
     (token: string) => {
@@ -71,15 +72,10 @@ export function usePresence(
 
   // Reset session when roomId/userId changes
   useEffect(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-
     if (sessionTokenRef.current) {
       void disconnect({ sessionToken: sessionTokenRef.current });
     }
-
-    setSessionId(Crypto.randomUUID());
+    sessionTokenRef.current = null;
     setSessionToken(null);
     setRoomToken(null);
   }, [roomId, userId, disconnect]);
@@ -89,6 +85,29 @@ export function usePresence(
   }, [sessionToken]);
 
   useEffect(() => {
+    let canceled = false;
+    activeSessionIdRef.current = sessionId;
+
+    const disconnectIfOrphaned = (token: string) => {
+      queueMicrotask(() => {
+        if (activeSessionIdRef.current !== sessionId) {
+          fireAndForgetDisconnect(token);
+        }
+      });
+    };
+
+    const sendHeartbeat = async () => {
+      const result = await heartbeat({ roomId, userId, sessionId, interval });
+      if (canceled) {
+        // Cleanup had no token for this in-flight heartbeat. Disconnect its
+        // session unless a newer effect now owns that same session.
+        disconnectIfOrphaned(result.sessionToken);
+        return;
+      }
+      setRoomToken(result.roomToken);
+      setSessionToken(result.sessionToken);
+    };
+
     // initial heartbeat + interval
     void sendHeartbeat();
     intervalRef.current = setInterval(sendHeartbeat, interval);
@@ -106,17 +125,21 @@ export function usePresence(
     });
 
     return () => {
+      canceled = true;
+      activeSessionIdRef.current = null;
+      const token = sessionTokenRef.current;
+
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
 
       subscription.remove();
 
-      if (sessionTokenRef.current) {
-        fireAndForgetDisconnect(sessionTokenRef.current);
+      if (token) {
+        disconnectIfOrphaned(token);
       }
     };
-  }, [roomId, userId, interval, sendHeartbeat, fireAndForgetDisconnect]);
+  }, [roomId, userId, sessionId, interval, heartbeat, fireAndForgetDisconnect]);
 
   const state = useQuery(presence.list, roomToken ? { roomToken } : "skip");
 

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -53,7 +53,6 @@ export function usePresence(
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const heartbeat = useSingleFlight(useMutation(presence.heartbeat));
-  // Every distinct token must be disconnected; useSingleFlight may drop calls.
   const disconnect = useMutation(presence.disconnect);
 
   const fireAndForgetDisconnect = useCallback(

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment happy-dom
+import { beforeEach, expect, test, vi } from "vitest";
+import { StrictMode, act } from "react";
+import { createRoot } from "react-dom/client";
+import usePresence, { type PresenceAPI } from "./index.js";
+
+// Response latency of the fake backend, long enough that effect cleanups
+// deterministically run while a heartbeat is still in flight.
+const LATENCY = 100;
+
+// A fake backend mirroring the presence component's semantics: state changes
+// apply in dispatch order (Convex runs a client's mutations in order) while
+// responses arrive after a delay; heartbeat reuses the session's token while
+// the session is alive and mints a new one if it was disconnected.
+const backend = vi.hoisted(() => {
+  let nextToken = 0;
+  const sessions = new Map<string, string>(); // sessionId -> live token
+  const issuedTokens = new Set<string>();
+  const disconnectedTokens = new Set<string>();
+  const heartbeat = async ({ sessionId }: { sessionId: string }) => {
+    let sessionToken = sessions.get(sessionId);
+    if (sessionToken === undefined) {
+      sessionToken = `token-${nextToken++}-${sessionId}`;
+      sessions.set(sessionId, sessionToken);
+    }
+    issuedTokens.add(sessionToken);
+    await new Promise((resolve) => setTimeout(resolve, LATENCY));
+    return { roomToken: "room-token", sessionToken };
+  };
+  const disconnect = async ({ sessionToken }: { sessionToken: string }) => {
+    disconnectedTokens.add(sessionToken);
+    for (const [sessionId, token] of sessions) {
+      if (token === sessionToken) {
+        sessions.delete(sessionId);
+      }
+    }
+  };
+  const reset = () => {
+    nextToken = 0;
+    sessions.clear();
+    issuedTokens.clear();
+    disconnectedTokens.clear();
+  };
+  return {
+    sessions,
+    issuedTokens,
+    disconnectedTokens,
+    heartbeat,
+    disconnect,
+    reset,
+  };
+});
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({ url: "https://test.convex.cloud" }),
+  // Identities must be stable across renders, like the real useMutation.
+  useMutation: (ref: unknown) =>
+    ref === "heartbeat" ? backend.heartbeat : backend.disconnect,
+  useQuery: () => undefined,
+}));
+
+const presenceApi = {
+  list: "list",
+  heartbeat: "heartbeat",
+  disconnect: "disconnect",
+} as unknown as PresenceAPI;
+
+function Component({
+  roomId = "room1",
+  userId = "user1",
+  interval = 10000,
+}: {
+  roomId?: string;
+  userId?: string;
+  interval?: number;
+}) {
+  usePresence(presenceApi, roomId, userId, interval);
+  return null;
+}
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  backend.reset();
+});
+
+const sleep = (ms: number) =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+
+function mount() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return createRoot(container);
+}
+
+test("strict mode reuses one session and disconnects it on unmount", async () => {
+  const root = mount();
+
+  // Strict mode mounts, unmounts, and remounts the component. The remount
+  // cleanup runs before the first heartbeat's response (and thus its session
+  // token) has arrived.
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <Component />
+      </StrictMode>,
+    );
+  });
+
+  // Let in-flight heartbeats resolve and their continuations run.
+  await sleep(5 * LATENCY);
+
+  // Both Strict Mode effect instances use the same stable session.
+  expect(backend.issuedTokens.size).toBe(1);
+  expect(backend.sessions.size).toBe(1);
+
+  await act(async () => {
+    root.unmount();
+  });
+  await sleep(LATENCY);
+
+  // Every session the backend ever created must be disconnected by now.
+  expect(backend.sessions.size).toBe(0);
+  expect([...backend.disconnectedTokens].sort()).toEqual(
+    [...backend.issuedTokens].sort(),
+  );
+});
+
+test("a room change disconnects an in-flight session", async () => {
+  const root = mount();
+
+  await act(async () => {
+    root.render(<Component roomId="room1" />);
+  });
+
+  // Change rooms before the first heartbeat response supplies its token.
+  await act(async () => {
+    root.render(<Component roomId="room2" />);
+  });
+  await sleep(5 * LATENCY);
+
+  expect(backend.issuedTokens.size).toBe(2);
+  expect(backend.disconnectedTokens.size).toBe(1);
+  expect(backend.sessions.size).toBe(1);
+
+  await act(async () => {
+    root.unmount();
+  });
+  await sleep(LATENCY);
+  expect(backend.sessions.size).toBe(0);
+  expect([...backend.disconnectedTokens].sort()).toEqual(
+    [...backend.issuedTokens].sort(),
+  );
+});
+
+test("a session taken over by a re-run effect is not disconnected", async () => {
+  const root = mount();
+
+  await act(async () => {
+    root.render(<Component interval={10000} />);
+  });
+  // Let the mount settle: one live session with its token stored.
+  await sleep(5 * LATENCY);
+  expect(backend.sessions.size).toBe(1);
+
+  // Changing `interval` re-runs the heartbeat effect WITHOUT rotating the
+  // sessionId, so the next effect instance heartbeats the same session...
+  await act(async () => {
+    root.render(<Component interval={20000} />);
+  });
+  // ...and before that heartbeat's response arrives, a second change cleans
+  // that instance up too. Its canceled continuation must recognize that the
+  // newest instance still owns the session and must NOT disconnect it.
+  await sleep(LATENCY / 2);
+  await act(async () => {
+    root.render(<Component interval={30000} />);
+  });
+  await sleep(5 * LATENCY);
+
+  // The user still has the original live session. Changing only the heartbeat
+  // interval must not disconnect and recreate it.
+  expect(backend.sessions.size).toBe(1);
+  expect(backend.issuedTokens.size).toBe(1);
+  expect(backend.disconnectedTokens.size).toBe(0);
+
+  await act(async () => {
+    root.unmount();
+  });
+  await sleep(LATENCY);
+  expect(backend.sessions.size).toBe(0);
+  expect([...backend.disconnectedTokens].sort()).toEqual(
+    [...backend.issuedTokens].sort(),
+  );
+});

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -79,10 +79,8 @@ export default function usePresence(
   const convex = useConvex();
   const baseUrl = convexUrl ?? convex.url;
 
-  // Each session (browser tab etc) has a unique ID and a token used to disconnect it.
-  // Keep one stable ID for this hook instance. Including the room and user
-  // rotates the server session synchronously when either identity changes,
-  // without creating a throwaway session during the initial effect.
+  // Each hook instance has a stable ID. Including the room and user gives each
+  // presence identity a distinct server session.
   const [instanceId] = useState(() => crypto.randomUUID());
   const sessionId = JSON.stringify([instanceId, roomId, userId]);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
@@ -128,8 +126,6 @@ export default function usePresence(
     const sendHeartbeat = async () => {
       const result = await heartbeat({ roomId, userId, sessionId, interval });
       if (canceled) {
-        // Cleanup had no token for this in-flight heartbeat. Disconnect its
-        // session unless a newer effect now owns that same session.
         disconnectIfOrphaned(result.sessionToken);
         return;
       }

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -96,7 +96,6 @@ export default function usePresence(
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const heartbeat = useSingleFlight(useMutation(presence.heartbeat));
-  // Every distinct token must be disconnected; useSingleFlight may drop calls.
   const disconnect = useMutation(presence.disconnect);
 
   useEffect(() => {

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -76,14 +76,19 @@ export default function usePresence(
   interval: number = 10000,
   convexUrl?: string,
 ): PresenceState[] | undefined {
-  const hasMounted = useRef(false);
   const convex = useConvex();
   const baseUrl = convexUrl ?? convex.url;
 
   // Each session (browser tab etc) has a unique ID and a token used to disconnect it.
-  const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
+  // Keep one stable ID for this hook instance. Including the room and user
+  // rotates the server session synchronously when either identity changes,
+  // without creating a throwaway session during the initial effect.
+  const [instanceId] = useState(() => crypto.randomUUID());
+  const sessionId = JSON.stringify([instanceId, roomId, userId]);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
   const sessionTokenRef = useRef<string | null>(null);
+  // A newer effect may adopt the same session when only `interval` changes.
+  const activeSessionIdRef = useRef<string | null>(null);
 
   const [roomToken, setRoomToken] = useState<string | null>(null);
   const roomTokenRef = useRef<string | null>(null);
@@ -91,21 +96,16 @@ export default function usePresence(
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const heartbeat = useSingleFlight(useMutation(presence.heartbeat));
-  const disconnect = useSingleFlight(useMutation(presence.disconnect));
+  // Every distinct token must be disconnected; useSingleFlight may drop calls.
+  const disconnect = useMutation(presence.disconnect);
 
   useEffect(() => {
-    // Reset session state when roomId or userId changes.
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-    if (sessionTokenRef.current) {
-      void disconnect({ sessionToken: sessionTokenRef.current });
-    }
-    setSessionId(crypto.randomUUID());
+    // The heartbeat effect cleans up the old session.
+    sessionTokenRef.current = null;
+    roomTokenRef.current = null;
     setSessionToken(null);
     setRoomToken(null);
-  }, [roomId, userId, disconnect]);
+  }, [roomId, userId]);
 
   useEffect(() => {
     // Update refs whenever tokens change.
@@ -114,9 +114,26 @@ export default function usePresence(
   }, [sessionToken, roomToken]);
 
   useEffect(() => {
+    let canceled = false;
+    activeSessionIdRef.current = sessionId;
+
+    const disconnectIfOrphaned = (token: string) => {
+      queueMicrotask(() => {
+        if (activeSessionIdRef.current !== sessionId) {
+          void disconnect({ sessionToken: token });
+        }
+      });
+    };
+
     // Periodic heartbeats.
     const sendHeartbeat = async () => {
       const result = await heartbeat({ roomId, userId, sessionId, interval });
+      if (canceled) {
+        // Cleanup had no token for this in-flight heartbeat. Disconnect its
+        // session unless a newer effect now owns that same session.
+        disconnectIfOrphaned(result.sessionToken);
+        return;
+      }
       setRoomToken(result.roomToken);
       setSessionToken(result.sessionToken);
     };
@@ -174,23 +191,19 @@ export default function usePresence(
 
     // Cleanup.
     return () => {
+      canceled = true;
+      activeSessionIdRef.current = null;
+      const token = sessionTokenRef.current;
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
       document.removeEventListener("visibilitychange", wrappedHandleVisibility);
       window.removeEventListener("beforeunload", handleUnload);
-      // Don't disconnect on first render in strict mode.
-      if (hasMounted.current) {
-        if (sessionTokenRef.current) {
-          void disconnect({ sessionToken: sessionTokenRef.current });
-        }
+      if (token) {
+        disconnectIfOrphaned(token);
       }
     };
   }, [heartbeat, disconnect, roomId, userId, baseUrl, interval, sessionId]);
-
-  useEffect(() => {
-    hasMounted.current = true;
-  }, []);
 
   const state = useQuery(presence.list, roomToken ? { roomToken } : "skip");
   return useMemo(


### PR DESCRIPTION
Fix presence sessions that can outlive the React effect that created them.

The previous hook rotated its session ID in a mount effect. That created a throwaway session on every mount, and cleanup could run before the first heartbeat returned the token needed to disconnect it. Similar races occurred during fast room or user changes. The server's expiration worker eventually cleans these sessions up, but they can remain visibly online for 2.5 heartbeat intervals.

This version:

- keeps a stable ID for each hook instance and derives the server session from that ID plus the room and user, so Strict Mode remounts share one session while room or user changes rotate synchronously;
- disconnects a late heartbeat response when no newer effect owns its session;
- defers cleanup disconnects by one microtask so interval-only effect reruns can adopt the existing session without an offline/online transition;
- sends every distinct disconnect instead of passing them through useSingleFlight, which may intentionally drop queued calls;
- applies the same lifecycle semantics to React and React Native.

Regression tests cover Strict Mode, a room change while the first heartbeat is in flight, and rapid interval changes that must preserve the active session.

Verification:

- npm test (23 tests)
- npm run lint
- npm run typecheck
- npm run build
- npm pack --dry-run
