### PR TITLE
Prevent duplicate React Native heartbeat intervals

### DIFF
--- a/src/react-native/index.test.tsx
+++ b/src/react-native/index.test.tsx
@@ -65,17 +65,23 @@ afterEach(() => {
 });
 
 test("returning from inactive replaces the heartbeat interval", async () => {
+  const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+  const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
   const root = createRoot(document.createElement("div"));
   await act(async () => root.render(<Component />));
 
-  expect(vi.getTimerCount()).toBe(1);
+  const initialInterval =
+    setIntervalSpy.mock.results[setIntervalSpy.mock.results.length - 1]?.value;
 
   act(() => appState.emit("inactive"));
-  expect(vi.getTimerCount()).toBe(1);
+  expect(clearIntervalSpy).not.toHaveBeenCalled();
 
   act(() => appState.emit("active"));
-  expect(vi.getTimerCount()).toBe(1);
+  expect(clearIntervalSpy).toHaveBeenCalledWith(initialInterval);
+  const replacementInterval =
+    setIntervalSpy.mock.results[setIntervalSpy.mock.results.length - 1]?.value;
+  expect(replacementInterval).not.toBe(initialInterval);
 
   await act(async () => root.unmount());
-  expect(vi.getTimerCount()).toBe(0);
+  expect(clearIntervalSpy).toHaveBeenCalledWith(replacementInterval);
 });

--- a/src/react-native/index.test.tsx
+++ b/src/react-native/index.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { usePresence, type PresenceAPI } from "./index.js";
+
+const appState = vi.hoisted(() => {
+  let listener: ((state: string) => void) | undefined;
+  return {
+    addEventListener: vi.fn(
+      (_event: string, nextListener: (state: string) => void) => {
+        listener = nextListener;
+        return { remove: vi.fn() };
+      },
+    ),
+    emit: (state: string) => listener?.(state),
+    reset: () => {
+      listener = undefined;
+    },
+  };
+});
+
+const backend = vi.hoisted(() => ({
+  heartbeat: vi.fn(() => new Promise<never>(() => {})),
+  disconnect: vi.fn(async () => null),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({ url: "https://test.convex.cloud" }),
+  useMutation: (ref: unknown) =>
+    ref === "heartbeat" ? backend.heartbeat : backend.disconnect,
+  useQuery: () => undefined,
+}));
+
+vi.mock("expo-crypto", () => ({
+  randomUUID: () => "instance-id",
+}));
+
+vi.mock("react-native", () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+
+const presenceApi = {
+  list: "list",
+  heartbeat: "heartbeat",
+  disconnect: "disconnect",
+} as unknown as PresenceAPI;
+
+function Component() {
+  usePresence(presenceApi, "room", "user");
+  return null;
+}
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  appState.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("returning from inactive replaces the heartbeat interval", async () => {
+  const root = createRoot(document.createElement("div"));
+  await act(async () => root.render(<Component />));
+
+  expect(vi.getTimerCount()).toBe(1);
+
+  act(() => appState.emit("inactive"));
+  expect(vi.getTimerCount()).toBe(1);
+
+  act(() => appState.emit("active"));
+  expect(vi.getTimerCount()).toBe(1);
+
+  await act(async () => root.unmount());
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -116,6 +116,10 @@ export function usePresence(
           fireAndForgetDisconnect(sessionTokenRef.current);
       } else if (state === "active") {
         void sendHeartbeat();
+        // iOS can go inactive -> active without entering the background.
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
         intervalRef.current = setInterval(sendHeartbeat, interval);
       }
     });


### PR DESCRIPTION
## Summary

Clear the existing React Native heartbeat interval before starting a replacement when the app becomes active.

## Why

On iOS, `AppState` can transition from `inactive` directly back to `active`, such as after opening Notification Center or receiving a call. The inactive state does not clear the running heartbeat interval. Starting another interval on the subsequent active event overwrites the stored timer handle while leaving the original timer running, so later cleanup cannot stop it.

The active handler now clears any existing timer before assigning the replacement.

## Verification

- Added a regression test covering `inactive` to `active` and asserting that exactly one interval remains.
- Confirmed the test fails with two active timers when the fix is removed.
- `npm test` (24 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run build`
