### PR TITLE
Update routine development dependencies

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
   zizmor:
     name: zizmor
@@ -40,4 +40,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Node setup
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           cache-dependency-path: package.json
           node-version: "24.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.38.0",
-        "@types/node": "24.13.2",
+        "@types/node": "24.13.3",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
@@ -2159,9 +2159,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.38.0",
-    "@types/node": "24.13.2",
+    "@types/node": "24.13.3",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@typescript-eslint/eslint-plugin": "^8.46.2",


### PR DESCRIPTION
Replaces #18 with the independently valid routine updates.

What changed:
- update the pinned actionlint, zizmor, and setup-node action digests
- update `@types/node` from 24.13.2 to 24.13.3 and regenerate its lockfile entry

This intentionally excludes the broad dev-dependency pinning and `@convex-dev/auth` update from #18. The auth update prevented npm from resolving the dependency tree, while `globals` and Vitest were already current in the lockfile.

Validation:
- `npm run build`
- `npm run test` (24 tests)
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
